### PR TITLE
Replace hard-coded host by dynamic host in front-end pages

### DIFF
--- a/socialNetwork/nginx-web-server/pages/compose.html
+++ b/socialNetwork/nginx-web-server/pages/compose.html
@@ -12,7 +12,7 @@ function clickEvent(){
     if (document.getElementById('media').value != "") {
         var formData = new FormData(document.getElementById('media-form'));
         const Http = new XMLHttpRequest();
-        const url='http://ath-8.ece.cornell.edu:8081/upload-media';
+        const url='http://' + window.location.hostname + ':8081/upload-media';
         Http.onreadystatechange = function() {
             if (this.readyState == 4 && this.status == 200) {
                 var resp = JSON.parse(Http.responseText);
@@ -31,7 +31,7 @@ function clickEvent(){
 function uploadPost(media_json) {
     if (document.getElementById('post_text').value !== "") {
         const Http = new XMLHttpRequest();
-        const url='http://ath-8.ece.cornell.edu:8080/api/post/compose';
+        const url='http://' + window.location.hostname + ':8080/api/post/compose';
         Http.open("POST", url, true);
         var body = "post_type=0&text=" + document.getElementById('post_text').value
         Http.onreadystatechange = function() {

--- a/socialNetwork/nginx-web-server/pages/home-timeline.html
+++ b/socialNetwork/nginx-web-server/pages/home-timeline.html
@@ -17,7 +17,7 @@
         if (start !== "" && stop !== "") {
             var params = "start=" + start + "&stop=" + stop;
             const Http = new XMLHttpRequest();
-            const url='http://ath-8.ece.cornell.edu:8080/api/home-timeline/read';
+            const url='http://' + window.location.hostname + ':8080/api/home-timeline/read';
             Http.open("GET", url + "?" + params, true);
             Http.onreadystatechange = function() {
                 if (this.readyState == 4 && this.status == 200) {
@@ -29,7 +29,7 @@
                         for (var j = 0; j < post_json["media"].length; j++) {
                             var media_json = post_json["media"][j];
                             var img = document.createElement("img");
-                            img.src = "http://ath-8.ece.cornell.edu:8081/get-media/?filename=" +
+                            img.src = "http://" + window.location.hostname + ":8081/get-media/?filename=" +
                                     media_json["media_id"] + "." +
                                     media_json["media_type"];
                             document.getElementById("block").appendChild(img);

--- a/socialNetwork/nginx-web-server/pages/user-timeline.html
+++ b/socialNetwork/nginx-web-server/pages/user-timeline.html
@@ -17,7 +17,7 @@
         if (start !== "" && stop !== "") {
             var params = "start=" + start + "&stop=" + stop;
             const Http = new XMLHttpRequest();
-            const url='http://ath-8.ece.cornell.edu:8080/api/user-timeline/read';
+            const url='http://' + window.location.hostname + ':8080/api/user-timeline/read';
             Http.open("GET", url + "?" + params, true);
             Http.onreadystatechange = function() {
                 if (this.readyState == 4 && this.status == 200) {


### PR DESCRIPTION
Front-end uses broken URI in Cornell university. 
Caution : unit tests still use these addresses.