### PR TITLE
Change return types of lua scripts

### DIFF
--- a/socialNetwork/docker/openresty-thrift/lua-thrift/GenericObjectPool.lua
+++ b/socialNetwork/docker/openresty-thrift/lua-thrift/GenericObjectPool.lua
@@ -37,20 +37,13 @@ end
 --设置连接池的大小
 --Maxtotal 连接池大小
 --
-function GenericObjectPool:setMaxSize(maxTotal)
+function GenericObjectPool:setMaxTotal(maxTotal)
   self.maxTotal = maxTotal
 end
-
-function GenericObjectPool:setMaxIdleTime(maxIdleTime)
-    self.maxIdleTime = maxIdleTime
-end
-
 function GenericObjectPool:clear()
 
 end
-
 function GenericObjectPool:remove()
 
 end
-
 return GenericObjectPool

--- a/socialNetwork/docker/openresty-thrift/lua-thrift/Object.lua
+++ b/socialNetwork/docker/openresty-thrift/lua-thrift/Object.lua
@@ -2,13 +2,13 @@
 ----Author: xiajun
 ----Date: 20151120
 ----
-function ttype(obj)
+local function ttype(obj)
     if type(obj) == 'table' and obj.__type and type(obj.__type) == 'string' then
         return obj.__type
     end
     return type(obj)
 end
-function __obj_index(self, key)
+local function __obj_index(self, key)
     local obj = rawget(self, key)
     if obj ~=nil then
         return obj
@@ -19,6 +19,7 @@ function __obj_index(self, key)
     end
     return nil
 end
+
 local Object = {
     __type = 'Object',
     __mt = {

--- a/socialNetwork/docker/openresty-thrift/lua-thrift/TBinaryProtocol.lua
+++ b/socialNetwork/docker/openresty-thrift/lua-thrift/TBinaryProtocol.lua
@@ -21,13 +21,13 @@ local TProtocol = require('TProtocol')
 local libluabpack = require('libluabpack')
 local libluabitwise = require('libluabitwise')
 local Thrift = require 'Thrift'
-local TType = Thrift[1]
-local __TObject = Thrift[3]
-local ttype = Thrift[8]
-local terror = Thrift[9]
-local TProtocolException = TProtocol[1]
-local TProtocolBase = TProtocol[2]
-local TProtocolFactory = TProtocol[3]
+local TType = Thrift.TType
+local __TObject = Thrift.__TObject
+local ttype = Thrift.ttype
+local terror = Thrift.terror
+local TProtocolException = TProtocol.TProtocolException
+local TProtocolBase = TProtocol.TProtocolBase
+local TProtocolFactory = TProtocol.TProtocolFactory
 
 
 local TBinaryProtocol = __TObject.new(TProtocolBase, {

--- a/socialNetwork/docker/openresty-thrift/lua-thrift/TBufferedTransport.lua
+++ b/socialNetwork/docker/openresty-thrift/lua-thrift/TBufferedTransport.lua
@@ -18,12 +18,12 @@
 --
 
 local TTransport = require 'TTransport'
-local TTransportException = TTransport[1]
-local TTransportBase = TTransport[2]
-local TTransportFactoryBase = TTransport[3]
+local TTransportException = TTransport.TTransportException
+local TTransportBase = TTransport.TTransportBase
+local TTransportFactoryBase = TTransport.TTransportFactoryBase
 local Thrift = require 'Thrift'
-local ttype = Thrift[8]
-local terror = Thrift[9]
+local ttype = Thrift.ttype
+local terror = Thrift.terror
 
 local TBufferedTransport = TTransportBase:new{
   __type = 'TBufferedTransport',

--- a/socialNetwork/docker/openresty-thrift/lua-thrift/TCompactProtocol.lua
+++ b/socialNetwork/docker/openresty-thrift/lua-thrift/TCompactProtocol.lua
@@ -22,15 +22,13 @@ local libluabpack = require 'libluabpack'
 local libluabitwise = require 'libluabitwise'
 local liblualongnumber = require 'liblualongnumber'
 local Thrift = require 'Thrift'
-local TType = Thrift[1]
-local __TObject = Thrift[3]
-local TException = Thrift[4]
-local ttype = Thrift[8]
-local terror = Thrift[9]
-local ttable_size = Thrift[10]
-local TProtocolException = TProtocol[1]
-local TProtocolBase = TProtocol[2]
-local TProtocolFactory = TProtocol[3]
+local TType = Thrift.TType
+local __TObject = Thrift.__TObject
+local ttype = Thrift.ttype
+local terror = Thrift.terror
+local TProtocolException = TProtocol.TProtocolException
+local TProtocolBase = TProtocol.TProtocolBase
+local TProtocolFactory = TProtocol.TProtocolFactory
 
 
 local TCompactProtocol = __TObject.new(TProtocolBase, {

--- a/socialNetwork/docker/openresty-thrift/lua-thrift/TFramedTransport.lua
+++ b/socialNetwork/docker/openresty-thrift/lua-thrift/TFramedTransport.lua
@@ -21,11 +21,11 @@ local TTransport = require 'TTransport'
 local libluabpack = require 'libluabpack'
 local TProtocol = require 'TProtocol'
 local Thrift = require 'Thrift'
-local TProtocolException = TProtocol[2]
-local TTransportBase = TTransport[2]
-local TTransportFactoryBase = TTransport[3]
-local ttype = Thrift[8]
-local terror = Thrift[9]
+local TProtocolException = TProtocol.TProtocolException
+local TTransportBase = TTransport.TTransportBase
+local TTransportFactoryBase = TTransport.TTransportFactoryBase
+local ttype = Thrift.ttype
+local terror = Thrift.terror
 
 
 local TFramedTransport = TTransportBase:new{

--- a/socialNetwork/docker/openresty-thrift/lua-thrift/THttpTransport.lua
+++ b/socialNetwork/docker/openresty-thrift/lua-thrift/THttpTransport.lua
@@ -17,11 +17,14 @@
 -- under the License.
 --
 
+local Thrift = require 'Thrift'
 local TTransport = require 'TTransport'
 local TProtocol = require 'TProtocol'
-local TProtocolException = TProtocol[2]
-local TTransportBase = TTransport[2]
-local TTransportFactoryBase = TTransport[3]
+local TProtocolException = TProtocol.TProtocolException
+local TTransportBase = TTransport.TTransportBase
+local TTransportFactoryBase = TTransport.TTransportFactoryBase
+local ttype = Thrift.ttype
+local terror = Thrift.terror
 
 local THttpTransport = TTransportBase:new{
   __type = 'THttpTransport',

--- a/socialNetwork/docker/openresty-thrift/lua-thrift/TJsonProtocol.lua
+++ b/socialNetwork/docker/openresty-thrift/lua-thrift/TJsonProtocol.lua
@@ -23,14 +23,13 @@ local libluabpack = require 'libluabpack'
 local libluabitwise = require 'libluabitwise'
 local liblualongnumber = require "liblualongnumber"
 
-local TType = Thrift[1]
-local __TObject = Thrift[3]
-local TException = Thrift[4]
-local TProtocolException = TProtocol[1]
-local TProtocolBase = TProtocol[2]
-local TProtocolFactory = TProtocol[3]
-local ttype = Thrift[8]
-local terror = Thrift[9]
+local TType = Thrift.TType
+local __TObject = Thrift.__TObject
+local TProtocolException = TProtocol.TProtocolException
+local TProtocolBase = TProtocol.TProtocolBase
+local TProtocolFactory = TProtocol.TProtocolFactory
+local ttype = Thrift.ttype
+local terror = Thrift.terror
 
 local TJSONProtocol = __TObject.new(TProtocolBase, {
   __type = 'TJSONProtocol',
@@ -92,9 +91,9 @@ local EscapeCharVals = {
 
 local JSONCharTable = {
   --0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
-  0,  0,  0,  0,  0,  0,  0,  0, 98,116,110,  0,102,114,  0,  0,
-  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
-  1,  1,34,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+    0,  0,  0,  0,  0,  0,  0,  0, 98,116,110,  0,102,114,  0,  0,
+    0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+    1,  1,34,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
 }
 
 -- character table string

--- a/socialNetwork/docker/openresty-thrift/lua-thrift/TMemoryBuffer.lua
+++ b/socialNetwork/docker/openresty-thrift/lua-thrift/TMemoryBuffer.lua
@@ -18,8 +18,10 @@
 --
 
 local TTransport = require 'TTransport'
-local TTransportException = TTransport[1]
-local TTransportBase = TTransport[2]
+local Thrift = require 'Thrift'
+local TTransportException = TTransport.TTransportException
+local TTransportBase = TTransport.TTransportBase
+local terror = Thrift.terror
 
 local TMemoryBuffer = TTransportBase:new{
   __type = 'TMemoryBuffer',

--- a/socialNetwork/docker/openresty-thrift/lua-thrift/TProtocol.lua
+++ b/socialNetwork/docker/openresty-thrift/lua-thrift/TProtocol.lua
@@ -18,9 +18,10 @@
 --
 
 local Thrift = require 'Thrift'
-local TType = Thrift[1]
-local __TObject = Thrift[3]
-local TException = Thrift[4]
+local TType = Thrift.TType
+local __TObject = Thrift.__TObject
+local TException = Thrift.TException
+local ttype = Thrift.ttype
 
 local TProtocolException = TException:new {
   UNKNOWN          = 0,
@@ -164,4 +165,8 @@ local TProtocolFactory = __TObject:new{
 }
 function TProtocolFactory:getProtocol(trans) end
 
-return {TProtocolException, TProtocolBase, TProtocolFactory}
+return {
+  TProtocolException=TProtocolException,
+  TProtocolBase=TProtocolBase,
+  TProtocolFactory=TProtocolFactory
+}

--- a/socialNetwork/docker/openresty-thrift/lua-thrift/TSocket.lua
+++ b/socialNetwork/docker/openresty-thrift/lua-thrift/TSocket.lua
@@ -17,12 +17,11 @@
 --
 
 local TTransport = require 'TTransport'
-local TTransportException = TTransport[1]
-local TTransportBase = TTransport[2]
+local TTransportException = TTransport.TTransportException
+local TTransportBase = TTransport.TTransportBase
 local Thrift = require 'Thrift'
-local ttype = Thrift[8]
-local terror = Thrift[9]
-
+local ttype = Thrift.ttype
+local terror = Thrift.terror
 
 -- TSocketBase
 local TSocketBase = TTransportBase:new{

--- a/socialNetwork/docker/openresty-thrift/lua-thrift/TTransport.lua
+++ b/socialNetwork/docker/openresty-thrift/lua-thrift/TTransport.lua
@@ -18,8 +18,9 @@
 --
 
 local Thrift = require('Thrift')
-local __TObject = Thrift[3]
-local TException = Thrift[4]
+local __TObject = Thrift.__TObject
+local TException = Thrift.TException
+local terror = Thrift.terror
 
 local TTransportException = TException:new {
   UNKNOWN             = 0,
@@ -94,4 +95,8 @@ function TTransportFactoryBase:getTransport(trans)
   return trans
 end
 
-return {TTransportException, TTransportBase, TTransportFactoryBase}
+return {
+  TTransportException=TTransportException,
+  TTransportBase=TTransportBase,
+  TTransportFactoryBase=TTransportFactoryBase
+}

--- a/socialNetwork/docker/openresty-thrift/lua-thrift/Thrift.lua
+++ b/socialNetwork/docker/openresty-thrift/lua-thrift/Thrift.lua
@@ -50,7 +50,6 @@ end
 
 local version = 1.0
 
--- Thrift[1]
 local TType = {
   STOP   = 0,
   VOID   = 1,
@@ -71,7 +70,6 @@ local TType = {
   UTF16  = 17
 }
 
--- Thrift[2]
 local TMessageType = {
   CALL  = 1,
   REPLY = 2,
@@ -80,7 +78,7 @@ local TMessageType = {
 }
 
 -- Recursive __index function to achieve inheritance
-function __tobj_index(self, key)
+local function __tobj_index(self, key)
   local v = rawget(self, key)
   if v ~= nil then
     return v
@@ -95,7 +93,6 @@ function __tobj_index(self, key)
 end
 
 -- Basic Thrift-Lua Object
--- Thrift[3]
 local __TObject = {
   __type = '__TObject',
   __mt = {
@@ -115,7 +112,7 @@ function __TObject:new(init_obj)
 end
 
 -- Return a string representation of any lua variable
-function thrift_print_r(t)
+local function thrift_print_r(t)
   local ret = ''
   local ltype = type(t)
   if (ltype == 'table') then
@@ -133,7 +130,6 @@ function thrift_print_r(t)
 end
 
 -- Basic Exception
--- Thrift[4]
 local TException = __TObject:new{
   message,
   errorCode,
@@ -239,7 +235,6 @@ function TException:write(oprot)
 end
 
 -- Basic Client (used in generated lua code)
--- Thrift[6]
 local __TClient = __TObject:new{
   __type = '__TClient',
   _seqid = 0
@@ -270,7 +265,6 @@ function __TClient:close()
 end
 
 -- Basic Processor (used in generated lua code)
--- Thrift[7]
 local __TProcessor = __TObject:new{
   __type = '__TProcessor'
 }
@@ -287,5 +281,15 @@ function __TProcessor:new(obj)
   return __TObject.new(self, obj)
 end
 
-return {TType, TMessageType, __TObject, TException,
-    TApplicationException, __TClient, __TProcessor, ttype, terror, ttable_size}
+return {
+    TType=TType,
+    TMessageType=TMessageType,
+    __TObject=__TObject,
+    TException=TException,
+    TApplicationException=TApplicationException,
+    __TClient=__TClient,
+    __TProcessor=__TProcessor,
+    ttype=ttype,
+    terror=terror,
+    ttable_size=ttable_size
+}

--- a/socialNetwork/gen-lua/social_network_HomeTimelineService.lua
+++ b/socialNetwork/gen-lua/social_network_HomeTimelineService.lua
@@ -7,17 +7,17 @@
 
 
 local Thrift = require 'Thrift'
-local TType = Thrift[1]
-local TMessageType = Thrift[2]
-local __TObject = Thrift[3]
-local TApplicationException = Thrift[5]
-local __TClient = Thrift[6]
-local __TProcessor = Thrift[7]
-local ttype = Thrift[8]
-local ttable_size = Thrift[10]
+local TType = Thrift.TType
+local TMessageType = Thrift.TMessageType
+local __TObject = Thrift.__TObject
+local TApplicationException = Thrift.TApplicationException
+local __TClient = Thrift.__TClient
+local __TProcessor = Thrift.__TProcessor
+local ttype = Thrift.ttype
+local ttable_size = Thrift.ttable_size
 local social_network_ttypes = require 'social_network_ttypes'
-local ServiceException = social_network_ttypes[4]
-local Post = social_network_ttypes[9]
+local ServiceException = social_network_ttypes.ServiceException
+local Post = social_network_ttypes.Post
 
 
 -- HELPER FUNCTIONS AND STRUCTURES

--- a/socialNetwork/gen-lua/social_network_MediaService.lua
+++ b/socialNetwork/gen-lua/social_network_MediaService.lua
@@ -7,16 +7,16 @@
 
 
 local Thrift = require 'Thrift'
-local TType = Thrift[1]
-local TMessageType = Thrift[2]
-local __TObject = Thrift[3]
-local TApplicationException = Thrift[5]
-local __TClient = Thrift[6]
-local __TProcessor = Thrift[7]
-local ttype = Thrift[8]
-local ttable_size = Thrift[10]
+local TType = Thrift.TType
+local TMessageType = Thrift.TMessageType
+local __TObject = Thrift.__TObject
+local TApplicationException = Thrift.TApplicationException
+local __TClient = Thrift.__TClient
+local __TProcessor = Thrift.__TProcessor
+local ttype = Thrift.ttype
+local ttable_size = Thrift.ttable_size
 local social_network_ttypes = require 'social_network_ttypes'
-local ServiceException = social_network_ttypes[4]
+local ServiceException = social_network_ttypes.ServiceException
 
 -- HELPER FUNCTIONS AND STRUCTURES
 

--- a/socialNetwork/gen-lua/social_network_SocialGraphService.lua
+++ b/socialNetwork/gen-lua/social_network_SocialGraphService.lua
@@ -6,16 +6,16 @@
 --
 
 local Thrift = require 'Thrift'
-local TType = Thrift[1]
-local TMessageType = Thrift[2]
-local __TObject = Thrift[3]
-local TApplicationException = Thrift[5]
-local __TClient = Thrift[6]
-local __TProcessor = Thrift[7]
-local ttype = Thrift[8]
-local ttable_size = Thrift[10]
+local TType = Thrift.TType
+local TMessageType = Thrift.TMessageType
+local __TObject = Thrift.__TObject
+local TApplicationException = Thrift.TApplicationException
+local __TClient = Thrift.__TClient
+local __TProcessor = Thrift.__TProcessor
+local ttype = Thrift.ttype
+local ttable_size = Thrift.ttable_size
 local social_network_ttypes = require 'social_network_ttypes'
-local ServiceException = social_network_ttypes[4]
+local ServiceException = social_network_ttypes.ServiceException
 
 
 -- HELPER FUNCTIONS AND STRUCTURES

--- a/socialNetwork/gen-lua/social_network_TextService.lua
+++ b/socialNetwork/gen-lua/social_network_TextService.lua
@@ -7,16 +7,16 @@
 
 
 local Thrift = require 'Thrift'
-local TType = Thrift[1]
-local TMessageType = Thrift[2]
-local __TObject = Thrift[3]
-local TApplicationException = Thrift[5]
-local __TClient = Thrift[6]
-local __TProcessor = Thrift[7]
-local ttype = Thrift[8]
-local ttable_size = Thrift[10]
+local TType = Thrift.TType
+local TMessageType = Thrift.TMessageType
+local __TObject = Thrift.__TObject
+local TApplicationException = Thrift.TApplicationException
+local __TClient = Thrift.__TClient
+local __TProcessor = Thrift.__TProcessor
+local ttype = Thrift.ttype
+local ttable_size = Thrift.ttable_size
 local social_network_ttypes = require 'social_network_ttypes'
-local ServiceException = social_network_ttypes[4]
+local ServiceException = social_network_ttypes.ServiceException
 
 -- HELPER FUNCTIONS AND STRUCTURES
 

--- a/socialNetwork/gen-lua/social_network_UniqueIdService.lua
+++ b/socialNetwork/gen-lua/social_network_UniqueIdService.lua
@@ -7,16 +7,16 @@
 
 
 local Thrift = require 'Thrift'
-local TType = Thrift[1]
-local TMessageType = Thrift[2]
-local __TObject = Thrift[3]
-local TApplicationException = Thrift[5]
-local __TClient = Thrift[6]
-local __TProcessor = Thrift[7]
-local ttype = Thrift[8]
-local ttable_size = Thrift[10]
+local TType = Thrift.TType
+local TMessageType = Thrift.TMessageType
+local __TObject = Thrift.__TObject
+local TApplicationException = Thrift.TApplicationException
+local __TClient = Thrift.__TClient
+local __TProcessor = Thrift.__TProcessor
+local ttype = Thrift.ttype
+local ttable_size = Thrift.ttable_size
 local social_network_ttypes = require 'social_network_ttypes'
-local ServiceException = social_network_ttypes[4]
+local ServiceException = social_network_ttypes.ServiceException
 
 -- HELPER FUNCTIONS AND STRUCTURES
 

--- a/socialNetwork/gen-lua/social_network_UserService.lua
+++ b/socialNetwork/gen-lua/social_network_UserService.lua
@@ -7,16 +7,16 @@
 
 
 local Thrift = require 'Thrift'
-local TType = Thrift[1]
-local TMessageType = Thrift[2]
-local __TObject = Thrift[3]
-local TApplicationException = Thrift[5]
-local __TClient = Thrift[6]
-local __TProcessor = Thrift[7]
-local ttype = Thrift[8]
-local ttable_size = Thrift[10]
+local TType = Thrift.TType
+local TMessageType = Thrift.TMessageType
+local __TObject = Thrift.__TObject
+local TApplicationException = Thrift.TApplicationException
+local __TClient = Thrift.__TClient
+local __TProcessor = Thrift.__TProcessor
+local ttype = Thrift.ttype
+local ttable_size = Thrift.ttable_size
 local social_network_ttypes = require 'social_network_ttypes'
-local ServiceException = social_network_ttypes[4]
+local ServiceException = social_network_ttypes.ServiceException
 
 -- HELPER FUNCTIONS AND STRUCTURES
 

--- a/socialNetwork/gen-lua/social_network_UserTimelineService.lua
+++ b/socialNetwork/gen-lua/social_network_UserTimelineService.lua
@@ -7,17 +7,17 @@
 
 
 local Thrift = require 'Thrift'
-local TType = Thrift[1]
-local TMessageType = Thrift[2]
-local __TObject = Thrift[3]
-local TApplicationException = Thrift[5]
-local __TClient = Thrift[6]
-local __TProcessor = Thrift[7]
-local ttype = Thrift[8]
-local ttable_size = Thrift[10]
+local TType = Thrift.TType
+local TMessageType = Thrift.TMessageType
+local __TObject = Thrift.__TObject
+local TApplicationException = Thrift.TApplicationException
+local __TClient = Thrift.__TClient
+local __TProcessor = Thrift.__TProcessor
+local ttype = Thrift.ttype
+local ttable_size = Thrift.ttable_size
 local social_network_ttypes = require 'social_network_ttypes'
-local ServiceException = social_network_ttypes[4]
-local Post = social_network_ttypes[9]
+local ServiceException = social_network_ttypes.ServiceException
+local Post = social_network_ttypes.Post
 
 -- HELPER FUNCTIONS AND STRUCTURES
 

--- a/socialNetwork/gen-lua/social_network_ttypes.lua
+++ b/socialNetwork/gen-lua/social_network_ttypes.lua
@@ -6,9 +6,9 @@
 --
 
 local Thrift = require 'Thrift'
-local TType = Thrift[1]
-local __TObject = Thrift[3]
-local TException = Thrift[4]
+local TType = Thrift.TType
+local __TObject = Thrift.__TObject
+local TException = Thrift.TException
 
 local ErrorCode = {
   SE_CONNPOOL_TIMEOUT = 0,
@@ -524,5 +524,14 @@ function Post:write(oprot)
   oprot:writeStructEnd()
 end
 
-return {ErrorCode, PostType, User, ServiceException, Media, Url,
-        UserMention, Creator, Post}
+return {
+  ErrorCode=ErrorCode,
+  PostType=PostType,
+  User=User,
+  ServiceException=ServiceException,
+  Media=Media,
+  Url=Url,
+  UserMention=UserMention,
+  Creator=Creator,
+  Post=Post
+}


### PR DESCRIPTION
The return types of the lua scripts are changed from arrays to tables for
better code readability