### PR TITLE
change nginx port back to 8080 in docker-compose.yml of socialNetwork…

### DIFF
--- a/mediaMicroservices/docker-compose.yml
+++ b/mediaMicroservices/docker-compose.yml
@@ -168,7 +168,7 @@ services:
     image: yg397/openresty-thrift:xenial
     hostname: nginx-thrift
     ports:
-      - 8082:8080
+      - 8080:8080
     restart: always
     volumes:
       - ./nginx-web-server/lua-scripts:/usr/local/openresty/nginx/lua-scripts

--- a/socialNetwork/docker-compose.yml
+++ b/socialNetwork/docker-compose.yml
@@ -221,7 +221,7 @@ services:
     image: yg397/openresty-thrift:xenial
     hostname: nginx-thrift
     ports:
-      - 8082:8080
+      - 8080:8080
     restart: always
     volumes:
       - ./nginx-web-server/lua-scripts:/usr/local/openresty/nginx/lua-scripts
@@ -254,4 +254,3 @@ services:
     restart: always
     environment:
       - COLLECTOR_ZIPKIN_HTTP_PORT=9411
-


### PR DESCRIPTION
… and mediaMicroservices

issue #30 and #37 are both about the misleading port 8082 in docker-compose.yml, sorry for the confusion, and I change the port back to 8080 in these two files in this PR.