### PR TITLE
Fixed Typo in Nginx Jaeger File

### DIFF
--- a/socialNetwork/nginx-web-server/jaeger-config.json
+++ b/socialNetwork/nginx-web-server/jaeger-config.json
@@ -1,6 +1,6 @@
 {
   "service_name": "nginx-web-server",
-  "diabled": false,
+  "disabled": false,
   "reporter": {
     "logSpans": true,
     "localAgentHostPort": "jaeger:6831"


### PR DESCRIPTION
Fixed a typo in the ```jaeger-config.json``` 