### PR TITLE
Wrkbugs

### DIFF
--- a/mediaMicroservices/wrk2/src/script.c
+++ b/mediaMicroservices/wrk2/src/script.c
@@ -26,19 +26,19 @@ static void set_fields(lua_State *, int, const table_field *);
 static void set_field(lua_State *, int, char *, int);
 static int push_url_part(lua_State *, char *, struct http_parser_url *, enum http_parser_url_fields);
 
-static const struct luaL_reg addrlib[] = {
+static const luaL_Reg addrlib[] = {
     { "__tostring", script_addr_tostring   },
     { "__gc"    ,   script_addr_gc         },
     { NULL,         NULL                   }
 };
 
-static const struct luaL_reg statslib[] = {
+static const luaL_Reg statslib[] = {
     { "__index",    script_stats_get       },
     { "__len",      script_stats_len       },
     { NULL,         NULL                   }
 };
 
-static const struct luaL_reg threadlib[] = {
+static const luaL_Reg threadlib[] = {
     { "__index",    script_thread_index    },
     { "__newindex", script_thread_newindex },
     { NULL,         NULL                   }

--- a/mediaMicroservices/wrk2/src/wrk.c
+++ b/mediaMicroservices/wrk2/src/wrk.c
@@ -735,7 +735,8 @@ static struct option longopts[] = {
 };
 
 static int parse_args(struct config *cfg, char **url, struct http_parser_url *parts, char **headers, int argc, char **argv) {
-    char c, **header = headers;
+    int c;
+    char **header = headers;
 
     memset(cfg, 0, sizeof(struct config));
     cfg->threads     = 2;

--- a/socialNetwork/wrk2/src/script.c
+++ b/socialNetwork/wrk2/src/script.c
@@ -26,19 +26,19 @@ static void set_fields(lua_State *, int, const table_field *);
 static void set_field(lua_State *, int, char *, int);
 static int push_url_part(lua_State *, char *, struct http_parser_url *, enum http_parser_url_fields);
 
-static const struct luaL_reg addrlib[] = {
+static const luaL_Reg addrlib[] = {
     { "__tostring", script_addr_tostring   },
     { "__gc"    ,   script_addr_gc         },
     { NULL,         NULL                   }
 };
 
-static const struct luaL_reg statslib[] = {
+static const luaL_Reg statslib[] = {
     { "__index",    script_stats_get       },
     { "__len",      script_stats_len       },
     { NULL,         NULL                   }
 };
 
-static const struct luaL_reg threadlib[] = {
+static const luaL_Reg threadlib[] = {
     { "__index",    script_thread_index    },
     { "__newindex", script_thread_newindex },
     { NULL,         NULL                   }

--- a/socialNetwork/wrk2/src/wrk.c
+++ b/socialNetwork/wrk2/src/wrk.c
@@ -735,7 +735,8 @@ static struct option longopts[] = {
 };
 
 static int parse_args(struct config *cfg, char **url, struct http_parser_url *parts, char **headers, int argc, char **argv) {
-    char c, **header = headers;
+    int c;
+    char **header = headers;
 
     memset(cfg, 0, sizeof(struct config));
     cfg->threads     = 2;


### PR DESCRIPTION
Hi, we are experimenting with running DeathStarBench on a PowerPC system, and ran into two bugs in the `wrk` command which prevented using it in that environment. 

1. The return value from `getopt_long()` is an `int`.  `wrk.c` stores this in a `char`. This causes problems with environments that consider `char` to be `unsigned` by default. -1 is returned when there is no input left. With an `unsigned char`, this is 255, which is then treated as invalid input.  The solution is to store the return value of `getopt_long()` with the documented type, `int`.

2. The declarations for `addrlib`, `statslib`, and `threadlib` are not usable on an RHEL/PowerPC system as they cause compile time errors. The proposed code change is minor, and compiles/runs successfully on both Ubuntu/X86 and RHEL/PowerPC systems.

Thank you,
Scott Trent