### PR TITLE
fix UrlShortenService compiler error

### DIFF
--- a/socialNetwork/src/UrlShortenService/UrlShortenHandler.h
+++ b/socialNetwork/src/UrlShortenService/UrlShortenHandler.h
@@ -39,12 +39,12 @@ class UrlShortenHandler : public UrlShortenServiceIf {
   memcached_pool_st *_memcached_client_pool;
   mongoc_client_pool_t *_mongodb_client_pool;
   ClientPool<ThriftClient<ComposePostServiceClient>> *_compose_client_pool;
-  thread_local std::mt19937 _generator;
+  static std::mt19937 _generator;
   static std::uniform_int_distribution<int> _distribution;
   static std::string _GenRandomStr(int length);
 };
 
-thread_local std::mt19937 UrlShortenHandler::_generator = std::mt19937(
+std::mt19937 UrlShortenHandler::_generator = std::mt19937(
     std::chrono::system_clock::now().time_since_epoch().count());
 std::uniform_int_distribution<int> UrlShortenHandler::_distribution =
     std::uniform_int_distribution<int>(0, 61);


### PR DESCRIPTION
Please refer to this issue: https://github.com/delimitrou/DeathStarBench/issues/77.

This PR reverts an inadvertent modification to the UrlShortenService.

Again, my apologies for introducing this error.