### PR TITLE
update obsolete apiVersion in HotelReservation OpenShift deployment configuration files

### DIFF
--- a/hotelReservation/openshift/consul-deployment.yaml
+++ b/hotelReservation/openshift/consul-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/hotelReservation/openshift/frontend-deployment.yaml
+++ b/hotelReservation/openshift/frontend-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/hotelReservation/openshift/geo-deployment.yaml
+++ b/hotelReservation/openshift/geo-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/hotelReservation/openshift/jaeger-deployment.yaml
+++ b/hotelReservation/openshift/jaeger-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/hotelReservation/openshift/memcached-profile-deployment.yaml
+++ b/hotelReservation/openshift/memcached-profile-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/hotelReservation/openshift/memcached-rate-deployment.yaml
+++ b/hotelReservation/openshift/memcached-rate-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/hotelReservation/openshift/memcached-reserve-deployment.yaml
+++ b/hotelReservation/openshift/memcached-reserve-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/hotelReservation/openshift/mongodb-geo-deployment.yaml
+++ b/hotelReservation/openshift/mongodb-geo-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/hotelReservation/openshift/mongodb-profile-deployment.yaml
+++ b/hotelReservation/openshift/mongodb-profile-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/hotelReservation/openshift/mongodb-rate-deployment.yaml
+++ b/hotelReservation/openshift/mongodb-rate-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/hotelReservation/openshift/mongodb-recommendation-deployment.yaml
+++ b/hotelReservation/openshift/mongodb-recommendation-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/hotelReservation/openshift/mongodb-reservation-deployment.yaml
+++ b/hotelReservation/openshift/mongodb-reservation-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/hotelReservation/openshift/mongodb-user-deployment.yaml
+++ b/hotelReservation/openshift/mongodb-user-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/hotelReservation/openshift/profile-deployment.yaml
+++ b/hotelReservation/openshift/profile-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/hotelReservation/openshift/rate-deployment.yaml
+++ b/hotelReservation/openshift/rate-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/hotelReservation/openshift/recommendation-deployment.yaml
+++ b/hotelReservation/openshift/recommendation-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/hotelReservation/openshift/reservation-deployment.yaml
+++ b/hotelReservation/openshift/reservation-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/hotelReservation/openshift/search-deployment.yaml
+++ b/hotelReservation/openshift/search-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/hotelReservation/openshift/user-deployment.yaml
+++ b/hotelReservation/openshift/user-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
"extensions/v1beta1" no longer accepted for Deployment yaml files....change to apps/v1.