### PR TITLE
Fix the user DB init bug

### DIFF
--- a/hotelReservation/cmd/user/db.go
+++ b/hotelReservation/cmd/user/db.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/sha256"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"strconv"
@@ -35,8 +36,10 @@ func initializeDatabase(url string) *mgo.Session {
 		if err != nil {
 			log.Fatal(err)
 		}
-		if count == 0{
-			err = c.Insert(&User{user_name, password})
+		if count == 0 {
+			sum := sha256.Sum256([]byte(password))
+			pass := fmt.Sprintf("%x", sum)
+			err = c.Insert(&User{user_name, pass})
 			if err != nil {
 				log.Fatal(err)
 			}


### PR DESCRIPTION
Fixes #104 of user DB init process in which it stores the plaintext of
password into DB, even though the user service is comparing the Sha256
of the password. This bug prevents the internal logic of reservation API
to fully do the job it's supposed to do.

Signed-off-by: Lianhao Lu <lianhao.lu@intel.com>