### PR TITLE
Disable TLS by Default

### DIFF
--- a/socialNetwork/config/mongod.conf
+++ b/socialNetwork/config/mongod.conf
@@ -1,4 +1,3 @@
 net:
   tls:
-    certificateKeyFile: /keys/server.pem
-    mode: requireTLS
+    mode: disabled

--- a/socialNetwork/config/redis.conf
+++ b/socialNetwork/config/redis.conf
@@ -1,5 +1,5 @@
-port 0
-tls-port 6379
+port 6379
+tls-port 0
 
 tls-cert-file /keys/server.crt
 tls-key-file /keys/server.key

--- a/socialNetwork/config/service-config.json
+++ b/socialNetwork/config/service-config.json
@@ -179,7 +179,7 @@
     "keepalive_ms": 10000
   },
   "ssl": {
-    "enabled": true,
+    "enabled": false,
     "caPath": "/keys/CA.pem",
     "ciphers": "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH",
     "serverKeyPath": "/keys/server.key",

--- a/socialNetwork/nginx-web-server/conf/nginx.conf
+++ b/socialNetwork/nginx-web-server/conf/nginx.conf
@@ -67,7 +67,7 @@ http {
     local config = ngx.shared.config;
     config:set("secret", "secret")
     config:set("cookie_ttl", 3600 * 24)
-    config:set("ssl", true)
+    config:set("ssl", false)
   }
 
   server {


### PR DESCRIPTION
Reverting the configuration files to disable TLS by default for consistency when the config container is not available (e.g., Kubernetes does not support `depends_on` syntax, `initContainers` could be a work-around though).