### PR TITLE
Fix errors that will make service terminated

### DIFF
--- a/hotelReservation/openshift/memcached-profile-deployment.yaml
+++ b/hotelReservation/openshift/memcached-profile-deployment.yaml
@@ -30,6 +30,7 @@ spec:
           value: "2"
         image: memcached
         name: hotel-reserv-profile-mmc
+        command: ["memcached", "-c", "65536"]
         ports:
         - containerPort: 11211
         resources: {}

--- a/hotelReservation/openshift/memcached-rate-deployment.yaml
+++ b/hotelReservation/openshift/memcached-rate-deployment.yaml
@@ -30,6 +30,7 @@ spec:
           value: "2"
         image: memcached
         name: hotel-reserv-rate-mmc
+        command: ["memcached", "-c", "65536"]
         ports:
         - containerPort: 11211
         resources: {}

--- a/hotelReservation/openshift/memcached-reserve-deployment.yaml
+++ b/hotelReservation/openshift/memcached-reserve-deployment.yaml
@@ -30,6 +30,7 @@ spec:
           value: "2"
         image: memcached
         name: hotel-reserv-reservation-mmc
+        command: ["memcached", "-c", "65536"]
         ports:
         - containerPort: 11211
         resources: {}

--- a/hotelReservation/services/frontend/server.go
+++ b/hotelReservation/services/frontend/server.go
@@ -192,6 +192,11 @@ func (s *Server) searchHandler(w http.ResponseWriter, r *http.Request) {
 		OutDate:      outDate,
 		RoomNumber:   1,
 	})
+	if err != nil {
+		fmt.Println("searchHandler CheckAvailability failed")
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	// fmt.Printf("searchHandler gets reserveResp\n")
 	// fmt.Printf("searchHandler gets reserveResp.HotelId = %s\n", reservationResp.HotelId)
@@ -202,6 +207,7 @@ func (s *Server) searchHandler(w http.ResponseWriter, r *http.Request) {
 		Locale:   locale,
 	})
 	if err != nil {
+		fmt.Println("searchHandler GetProfiles failed")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/hotelReservation/services/search/server.go
+++ b/hotelReservation/services/search/server.go
@@ -131,7 +131,8 @@ func (s *Server) Nearby(ctx context.Context, req *pb.NearbyRequest) (*pb.SearchR
 		Lon: req.Lon,
 	})
 	if err != nil {
-		log.Fatalf("nearby error: %v", err)
+		fmt.Printf("nearby error: %v", err)
+		return nil, err
 	}
 
 	// for _, hid := range nearby.HotelIds {
@@ -145,7 +146,8 @@ func (s *Server) Nearby(ctx context.Context, req *pb.NearbyRequest) (*pb.SearchR
 		OutDate:  req.OutDate,
 	})
 	if err != nil {
-		log.Fatalf("rates error: %v", err)
+		fmt.Printf("rates error: %v", err)
+		return nil, err
 	}
 
 	// TODO(hw): add simple ranking algo to order hotel ids:


### PR DESCRIPTION
Report a http 501 error when the backend service is not functional instead of terminate the service.