### PR TITLE
hotelReservation: support specifying TLS ciphersuite

### DIFF
--- a/hotelReservation/README.md
+++ b/hotelReservation/README.md
@@ -33,6 +33,9 @@ Supported actions:
 ##### Docker-compose
 - NOTLS: Start docker containers by running `docker-compose up -d`. All images will be pulled from Docker Hub.
 - TLS: Start docker containers by running `TLS=1 docker-compose up -d`. All the gRPC communications will be protected by TLS.
+- TLS with spcified ciphersuite: Start docker containers by running `TLS=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 docker-compose up -d`. The available cipher suite can be find at the file [options.go](tls/options.go#L21).
+
+Check if TLS is enabled or not: `docker-compose logs <service> | grep TLS`.
 
 ##### Openshift
 Read the Readme file in Openshift directory.

--- a/hotelReservation/tls/options.go
+++ b/hotelReservation/tls/options.go
@@ -1,7 +1,10 @@
 package tls
 
 import  (
+    "crypto/tls"
+    "crypto/x509"
     "fmt"
+    "io/ioutil"
     "log"
     "os"
     "strings"
@@ -14,29 +17,94 @@ import  (
 var (
     dialopt grpc.DialOption
     serveropt grpc.ServerOption
+    cipherSuites = map[string]uint16 {
+        // TLS 1.0 - 1.2 cipher suites.
+        "TLS_RSA_WITH_RC4_128_SHA": tls.TLS_RSA_WITH_RC4_128_SHA,
+        "TLS_RSA_WITH_3DES_EDE_CBC_SHA": tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+        "TLS_RSA_WITH_AES_128_CBC_SHA": tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+        "TLS_RSA_WITH_AES_256_CBC_SHA": tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+        "TLS_RSA_WITH_AES_128_CBC_SHA256": tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+        "TLS_RSA_WITH_AES_128_GCM_SHA256": tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+        "TLS_RSA_WITH_AES_256_GCM_SHA384": tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+
+        "TLS_ECDHE_RSA_WITH_RC4_128_SHA": tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+        "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA": tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA": tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA": tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256": tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256": tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384": tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256": tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+
+        // our certficate doesn't support ECDSA
+        /*
+        "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA": tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA": tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA": tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+        */
+
+        // TLS 1.3 cipher suites.
+        /* Not supported by golang v1.9
+        "TLS_AES_128_GCM_SHA256": tls.TLS_AES_128_GCM_SHA256,
+        "TLS_AES_256_GCM_SHA384": tls.TLS_AES_256_GCM_SHA384,
+        "TLS_CHACHA20_POLY1305_SHA256": tls.TLS_CHACHA20_POLY1305_SHA256,
+        */
+    }
 )
 
-
-func isTls() bool {
+func checkTLS() (bool, string) {
     if val, ok := os.LookupEnv("TLS"); ok {
         if ( strings.EqualFold(val, "false") || strings.EqualFold(val, "0") ) {
-            return false
-        }else {
-            return true
+            return false, ""
+        }
+        if ( strings.EqualFold(val, "true") || strings.EqualFold(val, "1") ) {
+            return true, ""
+        }
+
+        if _, ok := cipherSuites[val]; ok {
+            return true, val
+        } else {
+            log.Printf("WARNING: specified TLS cipher suite %s is invalid or unimplemented.\n", val)
+            validCiphers := make([]string, 0, len(cipherSuites))
+            for k := range(cipherSuites) {
+                validCiphers = append(validCiphers, k)
+            }
+            log.Printf("WARNING: Please use the supported TLS cipher suite %s\n", validCiphers)
+            return false, ""
         }
     }
-    return false
+    return false, ""
 }
 
-
 func init() {
-    if (isTls()) {
-        log.Println("TLS enabled")
-        creds, err := credentials.NewClientTLSFromFile("x509/ca_cert.pem", "x.test.example.com")
-        if err != nil {
-            panic(fmt.Sprintf("failed to load credentials: %v", err))
-	}
-	dialopt = grpc.WithTransportCredentials(creds)
+    needTLS, cipher := checkTLS()
+    if (needTLS) {
+        b, err := ioutil.ReadFile("x509/ca_cert.pem")
+	    if err != nil {
+		    panic(err)
+	    }
+	    cp := x509.NewCertPool()
+	    if !cp.AppendCertsFromPEM(b) {
+		    panic(fmt.Errorf("credentials: failed to append certificates"))
+        }
+        config := tls.Config{
+            ServerName: "x.test.example.com",
+            RootCAs: cp,
+        }
+        if cipher != "" {
+            log.Printf("TLS enabled cipher suite %s\n", cipher)
+            config.CipherSuites = append(config.CipherSuites, cipherSuites[cipher])
+        } else {
+            log.Println("TLS enabled without specified cipher suite")
+        }
+
+        var creds credentials.TransportCredentials
+        creds = credentials.NewTLS(&config)
+        dialopt = grpc.WithTransportCredentials(creds)
 
         creds, err = credentials.NewServerTLSFromFile("x509/server_cert.pem", "x509/server_key.pem")
         if err != nil {


### PR DESCRIPTION
Now we can specify the TLS ciphersuite by using environment variable TLS

TLS=1: default TLS cipher suite choose by golang TLS implementation
TLS=<cipher suite name>: use the specified TLS cipher suite 