### PR TITLE
hotelReservation: Fix unmarshal error in rate service

### DIFF
--- a/hotelReservation/services/rate/server.go
+++ b/hotelReservation/services/rate/server.go
@@ -118,7 +118,7 @@ func (s *Server) GetRates(ctx context.Context, req *pb.Request) (*pb.Result, err
 			for _, rate_str := range rate_strs {
 				if len(rate_str) != 0 {
 					rate_p := new(pb.RatePlan)
-					json.Unmarshal(item.Value, rate_p)
+					json.Unmarshal([]byte(rate_str), rate_p)
 					ratePlans = append(ratePlans, rate_p)
 				}
 			}


### PR DESCRIPTION
This patch fixes issue #130 which is caused by the unmarshal error
from memcached string. The error could result nil pointer in the
unmarshalled RatePlan object which would cause segmentation fault
during sorting.