### PR TITLE
Improve Dockerfile (faster build, smaller image, Dockerfile for loader)

### DIFF
--- a/socialNetwork/.dockerignore
+++ b/socialNetwork/.dockerignore
@@ -1,0 +1,6 @@
+*
+!/src/
+!/CMakeLists.txt
+!/cmake/
+!/gen-cpp/
+!/third_party/

--- a/socialNetwork/.dockerignore
+++ b/socialNetwork/.dockerignore
@@ -2,5 +2,8 @@
 !/src/
 !/CMakeLists.txt
 !/cmake/
+!/datasets/
 !/gen-cpp/
+!/scripts/
 !/third_party/
+!/wrk2/

--- a/socialNetwork/Dockerfile
+++ b/socialNetwork/Dockerfile
@@ -1,13 +1,11 @@
 FROM yg397/thrift-microservice-deps:xenial
 
-ARG NUM_CPUS=40
-
 COPY ./ /social-network-microservices
 RUN cd /social-network-microservices \
     && mkdir -p build \
     && cd build \
     && cmake -DCMAKE_BUILD_TYPE=Debug .. \
-    && make -j${NUM_CPUS} \
+    && make -j$(nproc) \
     && make install
 
 WORKDIR /social-network-microservices

--- a/socialNetwork/Dockerfile
+++ b/socialNetwork/Dockerfile
@@ -1,4 +1,4 @@
-FROM yg397/thrift-microservice-deps:xenial
+FROM yg397/thrift-microservice-deps:xenial AS builder
 
 COPY ./ /social-network-microservices
 RUN cd /social-network-microservices \
@@ -7,5 +7,21 @@ RUN cd /social-network-microservices \
     && cmake -DCMAKE_BUILD_TYPE=Debug .. \
     && make -j$(nproc) \
     && make install
+
+FROM ubuntu:16.04
+
+# Copy compiled C++ binaries and dependencies
+COPY --from=builder /usr/local/bin/* /usr/local/bin/
+COPY --from=builder /usr/local/lib/* /usr/local/lib/
+
+# Install system dependencies
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        openssl \
+        ca-certificates \
+        libsasl2-2 \
+        libmemcached11 \
+        libmemcachedutil2 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /social-network-microservices

--- a/socialNetwork/Dockerfile-loader
+++ b/socialNetwork/Dockerfile-loader
@@ -1,0 +1,43 @@
+FROM ubuntu:20.04 AS builder
+
+# Install build dependencies
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        build-essential \
+        ca-certificates \
+        libsasl2-2 \
+        libssl-dev \
+        openssl \
+        zlib1g-dev \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Copy wrk2 sources and build 
+COPY ./wrk2 /social-network-microservices/wrk2
+
+RUN cd /social-network-microservices/wrk2 \
+    && make -j$(nproc) \
+    && make install
+
+FROM ubuntu:20.04
+
+# Copy compiled C++ binaries and wrk2/scripts
+COPY --from=builder /usr/local/bin/* /usr/local/bin/
+COPY ./datasets /social-network-microservices/datasets/
+COPY ./scripts /social-network-microservices/scripts/
+COPY ./wrk2/scripts /social-network-microservices/wrk2/scripts
+
+# Install system dependencies
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        ca-certificates \
+        libsasl2-2 \
+        lua-socket \
+        openssl \
+        python3-aiohttp \
+        python3-minimal \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV LUA_PATH="/usr/share/lua/5.1/?.lua;/usr/share/lua/5.1/?;?.lua;?"
+ENV LUA_CPATH="/usr/lib/x86_64-linux-gnu/lua/5.1/?.so;?.so"
+
+WORKDIR /social-network-microservices

--- a/socialNetwork/README.md
+++ b/socialNetwork/README.md
@@ -50,7 +50,7 @@ docker stack deploy --compose-file=docker-compose-swarm.yml <service-name>
 
 ### Register users and construct social graphs
 
-Register users and construct social graph by running 
+Register users and construct social graph by running
 `python3 scripts/init_social_graph.py --graph=<soc-fb-Reed98, ego-twitter, or soc-twitter-follows-mun>`. It will initialize a social graph from a small social network [Reed98 Facebook Networks](http://networkrepository.com/socfb-Reed98.php), a medium social network [Ego Twitter](https://snap.stanford.edu/data/ego-Twitter.html), or a large social network [TWITTER-FOLLOWS-MUN](https://networkrepository.com/soc-twitter-follows-mun.php).
 
 ### Running HTTP workload generator
@@ -86,7 +86,7 @@ cd wrk2
 #### View Jaeger traces
 View Jaeger traces by accessing `http://localhost:16686`
 
-Example of a Jaeger trace for a compose post request: 
+Example of a Jaeger trace for a compose post request:
 
 ![jaeger_example](figures/socialNet_jaeger.png)
 
@@ -115,8 +115,8 @@ Click the contact button to follow/unfollow other users; follower/followee list 
 
 If you are using `docker-compose`, start docker containers by running `docker-compose -f docker-compose-tls.yml up -d` to enable TLS.
 
-Since the `depends_on` option is ignored when deploying a stack in swarm mode with a version 3 Compose file, you 
-must turn on TLS manually by modifing `config/mongod.conf`, `config/redis.conf`, `config/service-config.json` and 
+Since the `depends_on` option is ignored when deploying a stack in swarm mode with a version 3 Compose file, you
+must turn on TLS manually by modifing `config/mongod.conf`, `config/redis.conf`, `config/service-config.json` and
 `nginx-web-server/conf/nginx.conf` to enable TLS with `docker swarm`.
 
 ## Enable Redis Sharding
@@ -125,12 +125,12 @@ start docker containers by running `docker-compose -f docker-compose-sharding.ym
 
 ## Development Status
 
-This application is still actively being developed, so keep an eye on the repo to stay up-to-date with recent changes. 
+This application is still actively being developed, so keep an eye on the repo to stay up-to-date with recent changes.
 
 ### Planned updates
 
 * Upgraded recommender
-* Upgraded search engine 
+* Upgraded search engine
 * MongoDB and Memcached sharding
 
 ## Questions and contact

--- a/socialNetwork/datasets/social-graph/soc-twitter-follows-mun/readme.html
+++ b/socialNetwork/datasets/social-graph/soc-twitter-follows-mun/readme.html
@@ -1,6 +1,6 @@
 <html>
 <link rel="stylesheet" media="screen" href="http://networkrepository.com/assets/css/bootstrap.css">
-<link rel="stylesheet" href="http://networkrepository.com/assets/css/responsive.css">   
+<link rel="stylesheet" href="http://networkrepository.com/assets/css/responsive.css">
 <link rel="stylesheet" href="http://networkrepository.com/assets/css/style.css">
 
 <body>
@@ -14,7 +14,7 @@
     </div>
     <div class="panel-body">
         <h4>Please cite the following if you use the data:</h4>
-        <p class="lead12">           
+        <p class="lead12">
 
             <blockquote class="hero">
             <p style="font-family:'Lato';">

--- a/socialNetwork/datasets/social-graph/socfb-Reed98/readme.html
+++ b/socialNetwork/datasets/social-graph/socfb-Reed98/readme.html
@@ -1,6 +1,6 @@
 <html>
 <link rel="stylesheet" media="screen" href="http://networkrepository.com/assets/css/bootstrap.css">
-<link rel="stylesheet" href="http://networkrepository.com/assets/css/responsive.css">   
+<link rel="stylesheet" href="http://networkrepository.com/assets/css/responsive.css">
 <link rel="stylesheet" href="http://networkrepository.com/assets/css/style.css">
 
 <body>
@@ -13,9 +13,9 @@
         <h3 class="panel-title"><i class="icon-group icon-large"></i> Acknowledgement policy</h3>
     </div>
     <div class="panel-body">
-        <h4>Please acknowledge the <a href="http://networkrepository.com" target="_blank">repository</a> in published materials</h4> 
-        <p class="lead12">                    
-            If you publish material based on data obtained from this <a href="http://networkrepository.com" target="_blank">repository</a>, then, in your acknowledgements, please note the assistance you received by using <a href="http://networkrepository.com" target="_blank">network repository</a>. 
+        <h4>Please acknowledge the <a href="http://networkrepository.com" target="_blank">repository</a> in published materials</h4>
+        <p class="lead12">
+            If you publish material based on data obtained from this <a href="http://networkrepository.com" target="_blank">repository</a>, then, in your acknowledgements, please note the assistance you received by using <a href="http://networkrepository.com" target="_blank">network repository</a>.
             <BR><BR>
             Please use the following <code>BiBTeX</code> reference:<BR>
 

--- a/socialNetwork/docker-compose-sharding.yml
+++ b/socialNetwork/docker-compose-sharding.yml
@@ -43,7 +43,7 @@ services:
     depends_on:
       social-graph-redis:
         condition: service_started
-    volumes: 
+    volumes:
       - ./scripts:/scripts
     entrypoint: /bin/bash /scripts/setup_redis_cluster.sh -n social-graph-redis
 
@@ -63,7 +63,7 @@ services:
     depends_on:
       home-timeline-redis:
         condition: service_started
-    volumes: 
+    volumes:
       - ./scripts:/scripts
     entrypoint: /bin/bash /scripts/setup_redis_cluster.sh -n home-timeline-redis
 
@@ -142,7 +142,7 @@ services:
     depends_on:
       user-timeline-redis:
         condition: service_started
-    volumes: 
+    volumes:
       - ./scripts:/scripts
     entrypoint: /bin/bash /scripts/setup_redis_cluster.sh -n user-timeline-redis
 

--- a/socialNetwork/docker-compose-sharding.yml
+++ b/socialNetwork/docker-compose-sharding.yml
@@ -9,7 +9,7 @@ services:
     #    ports:
     #      - 10000:9090
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
       social-graph-mongodb:
         condition: service_started
@@ -74,7 +74,7 @@ services:
     #      - 10001:9090
     restart: always
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
     entrypoint: ComposePostService
     volumes:
@@ -87,7 +87,7 @@ services:
     #   - 10002:9090
     restart: always
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
       post-storage-mongodb:
         condition: service_started
@@ -116,7 +116,7 @@ services:
     #      - 10003:9090
     restart: always
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
       user-timeline-mongodb:
         condition: service_started
@@ -161,7 +161,7 @@ services:
     restart: always
     entrypoint: UrlShortenService
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
       url-shorten-mongodb:
         condition: service_started
@@ -189,7 +189,7 @@ services:
     #      - 10005:9090
     restart: always
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
       user-mongodb:
         condition: service_started
@@ -217,7 +217,7 @@ services:
     #    ports:
     #      - 10006:9090
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
       media-mongodb:
         condition: service_started
@@ -247,7 +247,7 @@ services:
     #      - 10007:9090
     restart: always
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
     entrypoint: TextService
     volumes:
@@ -260,7 +260,7 @@ services:
     #      - 10008:9090
     restart: always
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
     entrypoint: UniqueIdService
     volumes:
@@ -272,7 +272,7 @@ services:
     #    ports:
     #      - 10009:9090
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
     restart: always
     entrypoint: UserMentionService
@@ -285,7 +285,7 @@ services:
     #    ports:
     #      - 10010:9090
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
       home-timeline-redis-cluster-setup:
         condition: service_completed_successfully
@@ -300,7 +300,7 @@ services:
     ports:
       - 8080:8080
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
     restart: always
     volumes:
@@ -318,15 +318,14 @@ services:
       - 8081:8080
     restart: always
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
     volumes:
       - ./media-frontend/lua-scripts:/usr/local/openresty/nginx/lua-scripts
       - ./media-frontend/conf/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
 
-  jaeger:
+  jaeger-agent:
     image: jaegertracing/all-in-one:latest
-    hostname: jaeger-agent
     ports:
       #      - 5775:5775/udp
       #      - 6831:6831/udp

--- a/socialNetwork/docker-compose-swarm.yml
+++ b/socialNetwork/docker-compose-swarm.yml
@@ -99,7 +99,7 @@ services:
       - jaeger-query
     hostname: media-memcached
     image: memcached
-    command: 
+    command:
       - "-m 16384"
       - "-t 8"
       - "-I 32m"
@@ -168,7 +168,7 @@ services:
       - jaeger-query
     hostname: post-storage-memcached
     image: memcached
-    command: 
+    command:
       - "-m 16384"
       - "-t 8"
       - "-I 32m"
@@ -293,7 +293,7 @@ services:
       - jaeger-query
     hostname: url-shorten-memcached
     image: memcached
-    command: 
+    command:
       - "-m 16384"
       - "-t 8"
       - "-I 32m"
@@ -337,7 +337,7 @@ services:
       - jaeger-query
     hostname: user-memcached
     image: memcached
-    command: 
+    command:
       - "-m 16384"
       - "-t 8"
       - "-I 32m"

--- a/socialNetwork/docker-compose-tls.yml
+++ b/socialNetwork/docker-compose-tls.yml
@@ -18,7 +18,7 @@ services:
     depends_on:
       config:
         condition: service_completed_successfully
-      jaeger:
+      jaeger-agent:
         condition: service_started
       social-graph-mongodb:
         condition: service_started
@@ -79,7 +79,7 @@ services:
     depends_on:
       config:
         condition: service_completed_successfully
-      jaeger:
+      jaeger-agent:
         condition: service_started
     entrypoint: ComposePostService
     volumes:
@@ -95,7 +95,7 @@ services:
     depends_on:
       config:
         condition: service_completed_successfully
-      jaeger:
+      jaeger-agent:
         condition: service_started
       post-storage-mongodb:
         condition: service_started
@@ -137,7 +137,7 @@ services:
     depends_on:
       config:
         condition: service_completed_successfully
-      jaeger:
+      jaeger-agent:
         condition: service_started
       user-timeline-mongodb:
         condition: service_started
@@ -184,7 +184,7 @@ services:
     depends_on:
       config:
         condition: service_completed_successfully
-      jaeger:
+      jaeger-agent:
         condition: service_started
       url-shorten-mongodb:
         condition: service_started
@@ -225,7 +225,7 @@ services:
     depends_on:
       config:
         condition: service_completed_successfully
-      jaeger:
+      jaeger-agent:
         condition: service_started
       user-mongodb:
         condition: service_started
@@ -266,7 +266,7 @@ services:
     depends_on:
       config:
         condition: service_completed_successfully
-      jaeger:
+      jaeger-agent:
         condition: service_started
       media-mongodb:
         condition: service_started
@@ -309,7 +309,7 @@ services:
     depends_on:
       config:
         condition: service_completed_successfully
-      jaeger:
+      jaeger-agent:
         condition: service_started
     entrypoint: TextService
     volumes:
@@ -325,7 +325,7 @@ services:
     depends_on:
       config:
         condition: service_completed_successfully
-      jaeger:
+      jaeger-agent:
         condition: service_started
     entrypoint: UniqueIdService
     volumes:
@@ -340,7 +340,7 @@ services:
     depends_on:
       config:
         condition: service_completed_successfully
-      jaeger:
+      jaeger-agent:
         condition: service_started
     restart: always
     entrypoint: UserMentionService
@@ -356,7 +356,7 @@ services:
     depends_on:
       config:
         condition: service_completed_successfully
-      jaeger:
+      jaeger-agent:
         condition: service_started
     restart: always
     entrypoint: HomeTimelineService
@@ -372,7 +372,7 @@ services:
     depends_on:
       config:
         condition: service_completed_successfully
-      jaeger:
+      jaeger-agent:
         condition: service_started
     restart: always
     volumes:
@@ -393,15 +393,14 @@ services:
     depends_on:
       config:
         condition: service_completed_successfully
-      jaeger:
+      jaeger-agent:
         condition: service_started
     volumes:
       - ./media-frontend/lua-scripts:/usr/local/openresty/nginx/lua-scripts
       - ./media-frontend/conf/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
 
-  jaeger:
+  jaeger-agent:
     image: jaegertracing/all-in-one:latest
-    hostname: jaeger-agent
     ports:
       #      - 5775:5775/udp
       #      - 6831:6831/udp

--- a/socialNetwork/docker-compose.yml
+++ b/socialNetwork/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     #    ports:
     #      - 10000:9090
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
       social-graph-mongodb:
         condition: service_started
@@ -43,7 +43,7 @@ services:
     #      - 10001:9090
     restart: always
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
     entrypoint: ComposePostService
     volumes:
@@ -56,7 +56,7 @@ services:
       - 10002:9090
     restart: always
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
       post-storage-mongodb:
         condition: service_started
@@ -85,7 +85,7 @@ services:
     #      - 10003:9090
     restart: always
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
       user-timeline-mongodb:
         condition: service_started
@@ -115,7 +115,7 @@ services:
     restart: always
     entrypoint: UrlShortenService
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
       url-shorten-mongodb:
         condition: service_started
@@ -143,7 +143,7 @@ services:
     #      - 10005:9090
     restart: always
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
       user-mongodb:
         condition: service_started
@@ -171,7 +171,7 @@ services:
     #    ports:
     #      - 10006:9090
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
       media-mongodb:
         condition: service_started
@@ -201,7 +201,7 @@ services:
     #      - 10007:9090
     restart: always
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
     entrypoint: TextService
     volumes:
@@ -214,7 +214,7 @@ services:
     #      - 10008:9090
     restart: always
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
     entrypoint: UniqueIdService
     volumes:
@@ -226,7 +226,7 @@ services:
     #    ports:
     #      - 10009:9090
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
     restart: always
     entrypoint: UserMentionService
@@ -239,7 +239,7 @@ services:
     #    ports:
     #      - 10010:9090
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
     restart: always
     entrypoint: HomeTimelineService
@@ -252,7 +252,7 @@ services:
     ports:
       - 18080:8080
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
     restart: always
     volumes:
@@ -270,15 +270,14 @@ services:
       - 18081:8080
     restart: always
     depends_on:
-      jaeger:
+      jaeger-agent:
         condition: service_started
     volumes:
       - ./media-frontend/lua-scripts:/usr/local/openresty/nginx/lua-scripts
       - ./media-frontend/conf/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
 
-  jaeger:
+  jaeger-agent:
     image: jaegertracing/all-in-one:latest
-    hostname: jaeger-agent
     ports:
       #      - 5775:5775/udp
       #      - 6831:6831/udp

--- a/socialNetwork/docker/media-frontend/README.md
+++ b/socialNetwork/docker/media-frontend/README.md
@@ -100,7 +100,7 @@ nginx config files
 
 The Docker tooling installs its own [`nginx.conf` file](https://github.com/openresty/docker-openresty/blob/master/nginx.conf).  If you want to directly override it, you can replace it in your own Dockerfile or via volume bind-mounting.
 
-That `nginx.conf` has the directive `include /etc/nginx/conf.d/*.conf;` so all nginx configurations in that directory will be included.  The [default virtual host configuration](https://github.com/openresty/docker-openresty/blob/master/nginx.vh.default.conf) has the original OpenResty configuration and is copied to `/etc/nginx/conf.d/default.conf`. 
+That `nginx.conf` has the directive `include /etc/nginx/conf.d/*.conf;` so all nginx configurations in that directory will be included.  The [default virtual host configuration](https://github.com/openresty/docker-openresty/blob/master/nginx.vh.default.conf) has the original OpenResty configuration and is copied to `/etc/nginx/conf.d/default.conf`.
 
 You can override that `default.conf` directly or volume bind-mount the `/etc/nginx/conf.d` directory to your own set of configurations:
 

--- a/socialNetwork/docker/openresty-thrift/CHANGELOG.md
+++ b/socialNetwork/docker/openresty-thrift/CHANGELOG.md
@@ -30,7 +30,7 @@ Changelog
 
     * `centos-rpm` renamed to `centos`.  `centos-rpm` tag works but is deprecated.
 
-    * Archive `armhf-xenial`, `centos`, `jessie`, `trusty`, `wheezy` 
+    * Archive `armhf-xenial`, `centos`, `jessie`, `trusty`, `wheezy`
 
     * `alpine-fat` is now built on top of `alpine` rather than standalone
 

--- a/socialNetwork/docker/openresty-thrift/README.md
+++ b/socialNetwork/docker/openresty-thrift/README.md
@@ -75,7 +75,7 @@ Nginx Config Files
 
 The Docker tooling installs its own [`nginx.conf` file](https://github.com/openresty/docker-openresty/blob/master/nginx.conf).  If you want to directly override it, you can replace it in your own Dockerfile or via volume bind-mounting.
 
-For the Linux images, that `nginx.conf` has the directive `include /etc/nginx/conf.d/*.conf;` so all nginx configurations in that directory will be included.  The [default virtual host configuration](https://github.com/openresty/docker-openresty/blob/master/nginx.vh.default.conf) has the original OpenResty configuration and is copied to `/etc/nginx/conf.d/default.conf`. 
+For the Linux images, that `nginx.conf` has the directive `include /etc/nginx/conf.d/*.conf;` so all nginx configurations in that directory will be included.  The [default virtual host configuration](https://github.com/openresty/docker-openresty/blob/master/nginx.vh.default.conf) has the original OpenResty configuration and is copied to `/etc/nginx/conf.d/default.conf`.
 
 You can override that `default.conf` directly or volume bind-mount the `/etc/nginx/conf.d` directory to your own set of configurations:
 

--- a/socialNetwork/docker/openresty-thrift/lua-bridge-tracer/.clang-format
+++ b/socialNetwork/docker/openresty-thrift/lua-bridge-tracer/.clang-format
@@ -20,7 +20,7 @@ AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: true
 BinPackArguments: true
 BinPackParameters: true
-BraceWrapping:   
+BraceWrapping:
   AfterClass:      false
   AfterControlStatement: false
   AfterEnum:       false
@@ -48,7 +48,7 @@ DerivePointerAlignment: true
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
-IncludeCategories: 
+IncludeCategories:
   - Regex:           '^<.*\.h>'
     Priority:        1
   - Regex:           '^<.*'

--- a/socialNetwork/docker/openresty-thrift/lua-bridge-tracer/README.md
+++ b/socialNetwork/docker/openresty-thrift/lua-bridge-tracer/README.md
@@ -1,6 +1,6 @@
 # lua-bridge-tracer
 
-Provides an implementation of the [Lua OpenTracing API](https://github.com/opentracing/opentracing-lua) 
+Provides an implementation of the [Lua OpenTracing API](https://github.com/opentracing/opentracing-lua)
 on top of the [C++ OpenTracing API](https://github.com/opentracing/opentracing-cpp).
 
 Dependencies
@@ -29,7 +29,7 @@ library = --[[ path to OpenTracing plugin ]]
 config = --[[ vendor specific JSON configuration for the tracer ]]
 tracer = bridge_tracer:new(library, config)
 
--- `tracer` conforms to the Lua OpenTracing API. See 
+-- `tracer` conforms to the Lua OpenTracing API. See
 -- https://github.com/opentracing/opentracing-lua for API documentation.
 ```
 

--- a/socialNetwork/docker/openresty-thrift/lua-bridge-tracer/ci/setup_build_environment.sh
+++ b/socialNetwork/docker/openresty-thrift/lua-bridge-tracer/ci/setup_build_environment.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-apt-get update 
+apt-get update
 apt-get install --no-install-recommends --no-install-suggests -y \
                 ca-certificates \
                 build-essential \

--- a/socialNetwork/docker/openresty-thrift/lua-bridge-tracer/example/tutorial/tutorial.lua
+++ b/socialNetwork/docker/openresty-thrift/lua-bridge-tracer/example/tutorial/tutorial.lua
@@ -23,7 +23,7 @@ local parent_span = tracer:start_span("parent")
 
 -- create a child span
 local child_span = tracer:start_span(
-                    "ChildA", 
+                    "ChildA",
                     {["references"] = {{"child_of", parent_span:context()}}})
 
 child_span:set_tag("simple tag", 123)
@@ -37,7 +37,7 @@ local span_context = tracer:text_map_extract(carrier)
 assert(span_context ~= nil)
 
 local propagation_span = tracer:start_span(
-                      "PropagationSpan", 
+                      "PropagationSpan",
                       {["references"] = {{"follows_from", span_context}}})
 propagation_span:finish()
 

--- a/socialNetwork/docker/openresty-thrift/lua-bridge-tracer/test/tracer.lua
+++ b/socialNetwork/docker/openresty-thrift/lua-bridge-tracer/test/tracer.lua
@@ -7,7 +7,7 @@ function new_mocktracer(json_file)
     error("MOCKTRACER environmental variable must be set")
   end
   return bridge_tracer:new(
-            mocktracer_path, 
+            mocktracer_path,
             '{ "output_file":"' .. json_file .. '" }')
 end
 
@@ -199,7 +199,7 @@ describe("in bridge_tracer", function()
       context = nil
 
       -- free functions should be called for the tracer, span, and context
-      -- 
+      --
       -- when run with address sanitizer, leaks should be detected if they
       -- aren't freed
       collectgarbage()

--- a/socialNetwork/docker/openresty-thrift/lua-thrift/TSocket.lua
+++ b/socialNetwork/docker/openresty-thrift/lua-thrift/TSocket.lua
@@ -89,7 +89,7 @@ function TSocket:open()
         .. ' (' .. err .. ')'
     })
   end
-end    
+end
 
 function TSocket:read(len)
   local buf = self.handle:receive(len)

--- a/socialNetwork/docker/openresty-thrift/xenial/Dockerfile
+++ b/socialNetwork/docker/openresty-thrift/xenial/Dockerfile
@@ -14,7 +14,6 @@ ARG JAEGER_TRACING_VERSION="0.4.2"
 ARG NGINX_OPENTRACING_VERSION="0.8.0"
 ARG OPENTRACING_CPP_VERSION="1.5.1"
 ARG RESTY_J="1"
-ARG NUM_CPUS="40"
 ARG RESTY_CONFIG_OPTIONS="\
     --with-file-aio \
     --with-http_addition_module \
@@ -110,8 +109,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
              -DBUILD_STATIC_LIBS=OFF \
              -DBUILD_TESTING=OFF \
        .. \
-    && make -j${NUM_CPUS} \
-    && make -j${NUM_CPUS} install \
+    && make -j$(nproc) \
+    && make -j$(nproc) install \
     && cd /tmp \
     && rm -rf opentracing-cpp-${OPENTRACING_CPP_VERSION}.tar.gz \
               opentracing-cpp-${OPENTRACING_CPP_VERSION} \
@@ -190,8 +189,8 @@ RUN cd /usr/local/openresty/lualib/thrift/src \
     && cd cmake-build \
     && cmake -DCMAKE_BUILD_TYPE=Release \
        .. \
-    && make -j${NUM_CPUS} \
-    && make -j${NUM_CPUS} install
+    && make -j$(nproc) \
+    && make -j$(nproc) install
 #    && cd /tmp
 #    && rm -rf lua-bridge-tracer
 

--- a/socialNetwork/docker/thrift-microservice-deps/cpp/Dockerfile
+++ b/socialNetwork/docker/thrift-microservice-deps/cpp/Dockerfile
@@ -13,7 +13,6 @@ ARG LIB_SIMPLEAMQPCLIENT_VERSION=2.4.0
 ARG LIB_HIREDIS_VERSION=1.0.0
 ARG LIB_REDIS_PLUS_PLUS_VERSION=1.2.3
 
-ARG NUM_CPUS=40
 ARG BUILD_DEPS="ca-certificates g++ cmake wget git libmemcached-dev automake bison flex libboost-all-dev libevent-dev libssl-dev libtool make pkg-config librabbitmq-dev python3-dev python3-pip python3-setuptools python3-wheel"
 
 RUN apt-get update \
@@ -26,7 +25,7 @@ RUN apt-get update \
   && mkdir -p cmake-build \
   && cd cmake-build \
   && cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=0 -DENABLE_EXAMPLES=0 .. \
-  && make -j${NUM_CPUS} \
+  && make -j$(nproc) \
   && make install \
   && cd /tmp \
   # Install lib-thrift
@@ -36,7 +35,7 @@ RUN apt-get update \
   && mkdir -p cmake-build \
   && cd cmake-build \
   && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=0 .. \
-  && make -j${NUM_CPUS} \
+  && make -j$(nproc) \
   && make install \
   && cd /tmp \
   # Install /nlohmann/json
@@ -46,7 +45,7 @@ RUN apt-get update \
   && mkdir -p cmake-build \
   && cd cmake-build \
   && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=0 .. \
-  && make -j${NUM_CPUS} \
+  && make -j$(nproc) \
   && make install \
   && cd /tmp \
   # Install yaml-cpp
@@ -56,7 +55,7 @@ RUN apt-get update \
   && mkdir -p cmake-build \
   && cd cmake-build \
   && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-fPIC" -DYAML_CPP_BUILD_TESTS=0 .. \
-  && make -j${NUM_CPUS} \
+  && make -j$(nproc) \
   && make install \
   && cd /tmp \
   # Install opentracing-cpp
@@ -66,7 +65,7 @@ RUN apt-get update \
   && mkdir -p cmake-build \
   && cd cmake-build \
   && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-fPIC" -DBUILD_TESTING=0 .. \
-  && make -j${NUM_CPUS} \
+  && make -j$(nproc) \
   && make install \
   && cd /tmp \
   # Install jaeger-client-cpp
@@ -76,7 +75,7 @@ RUN apt-get update \
   && mkdir -p cmake-build \
   && cd cmake-build \
   && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-fPIC" -DHUNTER_ENABLED=0 -DBUILD_TESTING=0 -DJAEGERTRACING_WITH_YAML_CPP=1 -DJAEGERTRACING_BUILD_EXAMPLES=0 .. \
-  && make -j${NUM_CPUS} \
+  && make -j$(nproc) \
   && make install \
   && cd /tmp \
   # Install jwt
@@ -94,7 +93,7 @@ RUN apt-get update \
   && git submodule init && git submodule update \
   && mkdir cmake-build && cd cmake-build \
   && cmake .. -DCMAKE_BUILD_TYPE=Release \
-  && make -j${NUM_CPUS} \
+  && make -j$(nproc) \
   && make install \
   # Install AMQP-CPP
   && cd /tmp \
@@ -102,7 +101,7 @@ RUN apt-get update \
   && cd AMQP-CPP && git checkout v${LIB_AMQP_CPP_VERSION} \
   && mkdir cmake-build && cd cmake-build \
   && cmake .. -DCMAKE_BUILD_TYPE=Release -DAMQP-CPP_BUILD_SHARED=on -DAMQP-CPP_LINUX_TCP=on \
-  && make -j${NUM_CPUS} && make install \
+  && make -j$(nproc) && make install \
   # Install SimpleAmqpClient
   && cd /tmp \
   && git clone https://github.com/alanxz/SimpleAmqpClient.git \
@@ -110,14 +109,14 @@ RUN apt-get update \
   && git checkout v${LIB_SIMPLEAMQPCLIENT_VERSION} \
   && mkdir cmake-build && cd cmake-build \
   && cmake .. -DCMAKE_BUILD_TYPE=Release \
-  && make -j${NUM_CPUS} \
+  && make -j$(nproc) \
   && make install \
   # Install Hiredis
   && cd /tmp \
   && git clone https://github.com/redis/hiredis.git \
   && cd hiredis \
   && git checkout v${LIB_HIREDIS_VERSION} \
-  && make -j${NUM_CPUS} USE_SSL=1 \
+  && make -j$(nproc) USE_SSL=1 \
   && make USE_SSL=1 install \
   # Install Redis plus plus
   && cd /tmp \
@@ -125,7 +124,7 @@ RUN apt-get update \
   && cd redis-plus-plus \
   && git checkout ${LIB_REDIS_PLUS_PLUS_VERSION} \
   && cmake -DREDIS_PLUS_PLUS_USE_TLS=ON . \
-  && make -j${NUM_CPUS} \
+  && make -j$(nproc) \
   && make install \
   # Install pyyaml
   && pip3 install PyYAML \

--- a/socialNetwork/gen-cpp/ComposePostService.h
+++ b/socialNetwork/gen-cpp/ComposePostService.h
@@ -15,7 +15,7 @@ namespace social_network {
 
 #ifdef _MSC_VER
   #pragma warning( push )
-  #pragma warning (disable : 4250 ) //inheriting methods via dominance 
+  #pragma warning (disable : 4250 ) //inheriting methods via dominance
 #endif
 
 class ComposePostServiceIf {

--- a/socialNetwork/gen-cpp/HomeTimelineService.h
+++ b/socialNetwork/gen-cpp/HomeTimelineService.h
@@ -15,7 +15,7 @@ namespace social_network {
 
 #ifdef _MSC_VER
   #pragma warning( push )
-  #pragma warning (disable : 4250 ) //inheriting methods via dominance 
+  #pragma warning (disable : 4250 ) //inheriting methods via dominance
 #endif
 
 class HomeTimelineServiceIf {

--- a/socialNetwork/gen-cpp/MediaService.h
+++ b/socialNetwork/gen-cpp/MediaService.h
@@ -15,7 +15,7 @@ namespace social_network {
 
 #ifdef _MSC_VER
   #pragma warning( push )
-  #pragma warning (disable : 4250 ) //inheriting methods via dominance 
+  #pragma warning (disable : 4250 ) //inheriting methods via dominance
 #endif
 
 class MediaServiceIf {

--- a/socialNetwork/gen-cpp/PostStorageService.h
+++ b/socialNetwork/gen-cpp/PostStorageService.h
@@ -15,7 +15,7 @@ namespace social_network {
 
 #ifdef _MSC_VER
   #pragma warning( push )
-  #pragma warning (disable : 4250 ) //inheriting methods via dominance 
+  #pragma warning (disable : 4250 ) //inheriting methods via dominance
 #endif
 
 class PostStorageServiceIf {

--- a/socialNetwork/gen-cpp/SocialGraphService.h
+++ b/socialNetwork/gen-cpp/SocialGraphService.h
@@ -15,7 +15,7 @@ namespace social_network {
 
 #ifdef _MSC_VER
   #pragma warning( push )
-  #pragma warning (disable : 4250 ) //inheriting methods via dominance 
+  #pragma warning (disable : 4250 ) //inheriting methods via dominance
 #endif
 
 class SocialGraphServiceIf {

--- a/socialNetwork/gen-cpp/TextService.h
+++ b/socialNetwork/gen-cpp/TextService.h
@@ -15,7 +15,7 @@ namespace social_network {
 
 #ifdef _MSC_VER
   #pragma warning( push )
-  #pragma warning (disable : 4250 ) //inheriting methods via dominance 
+  #pragma warning (disable : 4250 ) //inheriting methods via dominance
 #endif
 
 class TextServiceIf {

--- a/socialNetwork/gen-cpp/UniqueIdService.h
+++ b/socialNetwork/gen-cpp/UniqueIdService.h
@@ -15,7 +15,7 @@ namespace social_network {
 
 #ifdef _MSC_VER
   #pragma warning( push )
-  #pragma warning (disable : 4250 ) //inheriting methods via dominance 
+  #pragma warning (disable : 4250 ) //inheriting methods via dominance
 #endif
 
 class UniqueIdServiceIf {

--- a/socialNetwork/gen-cpp/UrlShortenService.h
+++ b/socialNetwork/gen-cpp/UrlShortenService.h
@@ -15,7 +15,7 @@ namespace social_network {
 
 #ifdef _MSC_VER
   #pragma warning( push )
-  #pragma warning (disable : 4250 ) //inheriting methods via dominance 
+  #pragma warning (disable : 4250 ) //inheriting methods via dominance
 #endif
 
 class UrlShortenServiceIf {

--- a/socialNetwork/gen-cpp/UserMentionService.h
+++ b/socialNetwork/gen-cpp/UserMentionService.h
@@ -15,7 +15,7 @@ namespace social_network {
 
 #ifdef _MSC_VER
   #pragma warning( push )
-  #pragma warning (disable : 4250 ) //inheriting methods via dominance 
+  #pragma warning (disable : 4250 ) //inheriting methods via dominance
 #endif
 
 class UserMentionServiceIf {

--- a/socialNetwork/gen-cpp/UserService.h
+++ b/socialNetwork/gen-cpp/UserService.h
@@ -15,7 +15,7 @@ namespace social_network {
 
 #ifdef _MSC_VER
   #pragma warning( push )
-  #pragma warning (disable : 4250 ) //inheriting methods via dominance 
+  #pragma warning (disable : 4250 ) //inheriting methods via dominance
 #endif
 
 class UserServiceIf {

--- a/socialNetwork/gen-cpp/UserTimelineService.h
+++ b/socialNetwork/gen-cpp/UserTimelineService.h
@@ -15,7 +15,7 @@ namespace social_network {
 
 #ifdef _MSC_VER
   #pragma warning( push )
-  #pragma warning (disable : 4250 ) //inheriting methods via dominance 
+  #pragma warning (disable : 4250 ) //inheriting methods via dominance
 #endif
 
 class UserTimelineServiceIf {

--- a/socialNetwork/gen-lua/social_network_HomeTimelineService.lua
+++ b/socialNetwork/gen-lua/social_network_HomeTimelineService.lua
@@ -62,7 +62,7 @@ function ReadHomeTimeline_args:read(iprot)
     elseif fid == 5 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype151, _vtype152, _size150 = iprot:readMapBegin() 
+        local _ktype151, _vtype152, _size150 = iprot:readMapBegin()
         for _i=1,_size150 do
           local _key154 = iprot:readString()
           local _val155 = iprot:readString()
@@ -229,7 +229,7 @@ function WriteHomeTimeline_args:read(iprot)
     elseif fid == 6 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype170, _vtype171, _size169 = iprot:readMapBegin() 
+        local _ktype170, _vtype171, _size169 = iprot:readMapBegin()
         for _i=1,_size169 do
           local _key173 = iprot:readString()
           local _val174 = iprot:readString()

--- a/socialNetwork/gen-lua/social_network_MediaService.lua
+++ b/socialNetwork/gen-lua/social_network_MediaService.lua
@@ -145,7 +145,7 @@ function ComposeMedia_args:read(iprot)
     elseif fid == 4 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype331, _vtype332, _size330 = iprot:readMapBegin() 
+        local _ktype331, _vtype332, _size330 = iprot:readMapBegin()
         for _i=1,_size330 do
           local _key334 = iprot:readString()
           local _val335 = iprot:readString()

--- a/socialNetwork/gen-lua/social_network_PostStorageService.lua
+++ b/socialNetwork/gen-lua/social_network_PostStorageService.lua
@@ -232,7 +232,7 @@ function StorePost_args:read(iprot)
     elseif fid == 3 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype121, _vtype122, _size120 = iprot:readMapBegin() 
+        local _ktype121, _vtype122, _size120 = iprot:readMapBegin()
         for _i=1,_size120 do
           local _key124 = iprot:readString()
           local _val125 = iprot:readString()
@@ -339,7 +339,7 @@ function ReadPost_args:read(iprot)
     elseif fid == 3 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype129, _vtype130, _size128 = iprot:readMapBegin() 
+        local _ktype129, _vtype130, _size128 = iprot:readMapBegin()
         for _i=1,_size128 do
           local _key132 = iprot:readString()
           local _val133 = iprot:readString()
@@ -465,7 +465,7 @@ function ReadPosts_args:read(iprot)
     elseif fid == 3 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype142, _vtype143, _size141 = iprot:readMapBegin() 
+        local _ktype142, _vtype143, _size141 = iprot:readMapBegin()
         for _i=1,_size141 do
           local _key145 = iprot:readString()
           local _val146 = iprot:readString()

--- a/socialNetwork/gen-lua/social_network_TextService.lua
+++ b/socialNetwork/gen-lua/social_network_TextService.lua
@@ -125,7 +125,7 @@ function ComposeText_args:read(iprot)
     elseif fid == 3 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype39, _vtype40, _size38 = iprot:readMapBegin() 
+        local _ktype39, _vtype40, _size38 = iprot:readMapBegin()
         for _i=1,_size38 do
           local _key42 = iprot:readString()
           local _val43 = iprot:readString()

--- a/socialNetwork/gen-lua/social_network_UniqueIdService.lua
+++ b/socialNetwork/gen-lua/social_network_UniqueIdService.lua
@@ -125,7 +125,7 @@ function ComposeUniqueId_args:read(iprot)
     elseif fid == 3 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype31, _vtype32, _size30 = iprot:readMapBegin() 
+        local _ktype31, _vtype32, _size30 = iprot:readMapBegin()
         for _i=1,_size30 do
           local _key34 = iprot:readString()
           local _val35 = iprot:readString()

--- a/socialNetwork/gen-lua/social_network_UrlShortenService.lua
+++ b/socialNetwork/gen-lua/social_network_UrlShortenService.lua
@@ -187,7 +187,7 @@ function ComposeUrls_args:read(iprot)
     elseif fid == 3 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype286, _vtype287, _size285 = iprot:readMapBegin() 
+        local _ktype286, _vtype287, _size285 = iprot:readMapBegin()
         for _i=1,_size285 do
           local _key289 = iprot:readString()
           local _val290 = iprot:readString()
@@ -327,7 +327,7 @@ function GetExtendedUrls_args:read(iprot)
     elseif fid == 3 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype306, _vtype307, _size305 = iprot:readMapBegin() 
+        local _ktype306, _vtype307, _size305 = iprot:readMapBegin()
         for _i=1,_size305 do
           local _key309 = iprot:readString()
           local _val310 = iprot:readString()

--- a/socialNetwork/gen-lua/social_network_UserMentionService.lua
+++ b/socialNetwork/gen-lua/social_network_UserMentionService.lua
@@ -131,7 +131,7 @@ function ComposeUserMentions_args:read(iprot)
     elseif fid == 3 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype266, _vtype267, _size265 = iprot:readMapBegin() 
+        local _ktype266, _vtype267, _size265 = iprot:readMapBegin()
         for _i=1,_size265 do
           local _key269 = iprot:readString()
           local _val270 = iprot:readString()

--- a/socialNetwork/media-frontend/conf/nginx.conf
+++ b/socialNetwork/media-frontend/conf/nginx.conf
@@ -5,7 +5,7 @@ worker_processes  16;
 # error_log  logs/error.log;
 
 # Checklist: Make sure that worker_connections * worker_processes
-# is greater than the total connections between the client and Nginx. 
+# is greater than the total connections between the client and Nginx.
 events {
   worker_connections  1024;
 }

--- a/socialNetwork/nginx-web-server/conf/nginx-tls.conf
+++ b/socialNetwork/nginx-web-server/conf/nginx-tls.conf
@@ -8,7 +8,7 @@ worker_processes  auto;
 # error_log  logs/error.log;
 
 # Checklist: Make sure that worker_connections * worker_processes
-# is greater than the total connections between the client and Nginx. 
+# is greater than the total connections between the client and Nginx.
 events {
   worker_connections  1024;
 }

--- a/socialNetwork/nginx-web-server/conf/nginx.conf
+++ b/socialNetwork/nginx-web-server/conf/nginx.conf
@@ -8,7 +8,7 @@ worker_processes  auto;
 # error_log  logs/error.log;
 
 # Checklist: Make sure that worker_connections * worker_processes
-# is greater than the total connections between the client and Nginx. 
+# is greater than the total connections between the client and Nginx.
 events {
   worker_connections  1024;
 }

--- a/socialNetwork/nginx-web-server/lua-scripts/api/home-timeline/read.lua
+++ b/socialNetwork/nginx-web-server/lua-scripts/api/home-timeline/read.lua
@@ -71,7 +71,7 @@ function _M.ReadHomeTimeline()
     -- ngx.redirect("../../index.html")
     -- ngx.exit(ngx.HTTP_OK)
     ngx.exit(ngx.HTTP_UNAUTHORIZED)
-    
+
   end
 
 
@@ -82,7 +82,7 @@ function _M.ReadHomeTimeline()
     -- ngx.say(login_obj.reason);
     -- ngx.exit(ngx.HTTP_OK)
     ngx.exit(ngx.HTTP_UNAUTHORIZED)
-    
+
   end
 
 
@@ -103,7 +103,7 @@ function _M.ReadHomeTimeline()
     -- ngx.say("Login token expired, please log in again")
     -- ngx.exit(ngx.HTTP_OK)
     ngx.exit(ngx.HTTP_UNAUTHORIZED)
-    
+
   else
     local client = GenericObjectPool:connection(
         HomeTimelineServiceClient, "home-timeline-service", 9090)

--- a/socialNetwork/nginx-web-server/lua-scripts/api/post/compose.lua
+++ b/socialNetwork/nginx-web-server/lua-scripts/api/post/compose.lua
@@ -89,7 +89,7 @@ function _M.ComposePost()
       client.iprot.trans:close()
       ngx.exit(ngx.status)
     end
-  
+
     GenericObjectPool:returnConnection(client)
     ngx.status = ngx.HTTP_OK
     ngx.say("Successfully upload post")

--- a/socialNetwork/nginx-web-server/lua-scripts/api/user/follow.lua
+++ b/socialNetwork/nginx-web-server/lua-scripts/api/user/follow.lua
@@ -26,7 +26,7 @@ function _M.Follow()
   local client = GenericObjectPool:connection(
       SocialGraphServiceClient, "social-graph-service", 9090)
 
-  -- -- new start -- 
+  -- -- new start --
   -- if (_StrIsEmpty(ngx.var.cookie_login_token)) then
   --   ngx.status = ngx.HTTP_UNAUTHORIZED
   --   ngx.exit(ngx.HTTP_OK)
@@ -66,7 +66,7 @@ function _M.Follow()
     ngx.log(ngx.ERR, "Follow Failed: " .. err.message)
     ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
   end
-  
+
   GenericObjectPool:returnConnection(client)
   span:finish()
   ngx.redirect("../../contact.html")

--- a/socialNetwork/nginx-web-server/lua-scripts/api/user/login.lua
+++ b/socialNetwork/nginx-web-server/lua-scripts/api/user/login.lua
@@ -55,7 +55,7 @@ function _M.Login()
     ngx.header.content_type = "text/plain"
     ngx.header["Set-Cookie"] = "login_token=" .. ret .. "; Path=/; Expires="
         .. ngx.cookie_time(ngx.time() + ngx.shared.config:get("cookie_ttl"))
-    
+
     ngx.redirect("../../main.html?username=" .. args.username)
     ngx.exit(ngx.HTTP_OK)
   end

--- a/socialNetwork/nginx-web-server/lua-scripts/wrk2-api/post/compose.lua
+++ b/socialNetwork/nginx-web-server/lua-scripts/wrk2-api/post/compose.lua
@@ -18,7 +18,7 @@ function _M.ComposePost()
   local req_id = tonumber(string.sub(ngx.var.request_id, 0, 15), 16)
   local tracer = bridge_tracer.new_from_global()
   local parent_span_context = tracer:binary_extract(ngx.var.opentracing_binary_context)
-  
+
 
   ngx.req.read_body()
   local post = ngx.req.get_post_args()

--- a/socialNetwork/nginx-web-server/pages/jaeger-config.json
+++ b/socialNetwork/nginx-web-server/pages/jaeger-config.json
@@ -3,7 +3,7 @@
   "diabled": false,
   "reporter": {
     "logSpans": true,
-    "localAgentHostPort": "jaeger:6831"
+    "localAgentHostPort": "jaeger-agent:6831"
   },
   "sampler": {
     "type": "const",

--- a/socialNetwork/openshift/README.md
+++ b/socialNetwork/openshift/README.md
@@ -35,7 +35,7 @@ After customization, If you are running "on-cluster" copy necessary files to `ub
 - If using an on-cluster client:
   - Use `nginx-thrift.social-network.svc.cluster.local` as cluster-ip and paste it at `<path-of-repo>/socialNetwork/scripts/init_social_graph.py:72`
 - Register users and construct social graph by running `cd <path-of-repo>/socialNetwork && python3 scripts/init_social_graph.py`.
-  This will initialize a social graph based on [Reed98 Facebook Networks](http://networkrepository.com/socfb-Reed98.php), with 962 users and 18.8K social graph edges. 
+  This will initialize a social graph based on [Reed98 Facebook Networks](http://networkrepository.com/socfb-Reed98.php), with 962 users and 18.8K social graph edges.
 
 ### Running HTTP workload generator
 
@@ -77,12 +77,12 @@ cd <path-of-repo>/socialNetwork/wrk2
 
 Use `oc -n social-network get svc jaeger-out` to get the NodePort of jaeger service.
 
- View Jaeger traces by accessing `http://<node-ip>:<NodePort>` 
+ View Jaeger traces by accessing `http://<node-ip>:<NodePort>`
 
 
 ### OpenShift SCC
 
-Original containers are expected to run as root, but OpenShift does not permit it as a default policy. 
+Original containers are expected to run as root, but OpenShift does not permit it as a default policy.
 As a workaround for simplicity, we can relax security policy by adding several SCCs to each project.
 
 ```

--- a/socialNetwork/openshift/compose-post-redis.yaml
+++ b/socialNetwork/openshift/compose-post-redis.yaml
@@ -30,7 +30,7 @@ spec:
       app: compose-post-redis
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: compose-post-redis
       name: compose-post-redis

--- a/socialNetwork/openshift/compose-post-service.yaml
+++ b/socialNetwork/openshift/compose-post-service.yaml
@@ -32,7 +32,7 @@ spec:
       app: compose-post-service
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: compose-post-service
       name: compose-post-service

--- a/socialNetwork/openshift/home-timeline-redis.yaml
+++ b/socialNetwork/openshift/home-timeline-redis.yaml
@@ -30,7 +30,7 @@ spec:
       app: home-timeline-redis
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: home-timeline-redis
       name: home-timeline-redis

--- a/socialNetwork/openshift/home-timeline-service.yaml
+++ b/socialNetwork/openshift/home-timeline-service.yaml
@@ -30,7 +30,7 @@ spec:
       app: home-timeline-service
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: home-timeline-service
       name: home-timeline-service

--- a/socialNetwork/openshift/jaeger.yaml
+++ b/socialNetwork/openshift/jaeger.yaml
@@ -18,7 +18,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: jaeger
+  name: jaeger-agent
   labels:
     death-star-project: social-network
     app-name: jaeger
@@ -47,7 +47,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: jaeger
+  name: jaeger-agent
   labels:
     death-star-project: social-network
     app-name: jaeger
@@ -63,12 +63,14 @@ spec:
       labels:
         death-star-project: social-network
         app-name: jaeger
-      name: jaeger
+      name: jaeger-agent
     spec:
       containers:
-      - name: jaeger
+      - name: jaeger-agent
         image: jaegertracing/all-in-one:latest
         env:
         - name: COLLECTOR_ZIPKIN_HTTP_PORT
           value: "9411"
+        - name: JAEGER_AGENT_PORT
+          value: "5775"
       restartPolicy: Always

--- a/socialNetwork/openshift/jaeger.yaml
+++ b/socialNetwork/openshift/jaeger.yaml
@@ -60,7 +60,7 @@ spec:
       app-name: jaeger
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app-name: jaeger
       name: jaeger

--- a/socialNetwork/openshift/media-frontend-config/nginx.conf
+++ b/socialNetwork/openshift/media-frontend-config/nginx.conf
@@ -5,7 +5,7 @@ worker_processes  16;
 # error_log  logs/error.log;
 
 # Checklist: Make sure that worker_connections * worker_processes
-# is greater than the total connections between the client and Nginx. 
+# is greater than the total connections between the client and Nginx.
 events {
   worker_connections  1024;
 }

--- a/socialNetwork/openshift/media-frontend.yaml
+++ b/socialNetwork/openshift/media-frontend.yaml
@@ -32,7 +32,7 @@ spec:
       app: media-frontend
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: media-frontend
       name: media-frontend
@@ -40,7 +40,7 @@ spec:
       containers:
       - name: media-frontend
         image: yg397/media-frontend:xenial
-        ports: 
+        ports:
         - containerPort: 8080
         volumeMounts:
         - mountPath: /usr/local/openresty/nginx/lua-scripts

--- a/socialNetwork/openshift/media-memcached.yaml
+++ b/socialNetwork/openshift/media-memcached.yaml
@@ -30,7 +30,7 @@ spec:
       app: media-memcached
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: media-memcached
       name: media-memcached

--- a/socialNetwork/openshift/media-mongodb.yaml
+++ b/socialNetwork/openshift/media-mongodb.yaml
@@ -30,7 +30,7 @@ spec:
       app: media-mongodb
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: media-mongodb
       name: media-mongodb

--- a/socialNetwork/openshift/media-service.yaml
+++ b/socialNetwork/openshift/media-service.yaml
@@ -30,7 +30,7 @@ spec:
       app: media-service
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: media-service
       name: media-service

--- a/socialNetwork/openshift/nginx-thrift-config/gen-lua/social_network_ComposePostService.lua
+++ b/socialNetwork/openshift/nginx-thrift-config/gen-lua/social_network_ComposePostService.lua
@@ -370,7 +370,7 @@ function UploadText_args:read(iprot)
     elseif fid == 3 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype75, _vtype76, _size74 = iprot:readMapBegin() 
+        local _ktype75, _vtype76, _size74 = iprot:readMapBegin()
         for _i=1,_size74 do
           local _key78 = iprot:readString()
           local _val79 = iprot:readString()
@@ -484,7 +484,7 @@ function UploadMedia_args:read(iprot)
     elseif fid == 3 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype88, _vtype89, _size87 = iprot:readMapBegin() 
+        local _ktype88, _vtype89, _size87 = iprot:readMapBegin()
         for _i=1,_size87 do
           local _key91 = iprot:readString()
           local _val92 = iprot:readString()
@@ -602,7 +602,7 @@ function UploadUniqueId_args:read(iprot)
     elseif fid == 4 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype97, _vtype98, _size96 = iprot:readMapBegin() 
+        local _ktype97, _vtype98, _size96 = iprot:readMapBegin()
         for _i=1,_size96 do
           local _key100 = iprot:readString()
           local _val101 = iprot:readString()
@@ -715,7 +715,7 @@ function UploadCreator_args:read(iprot)
     elseif fid == 3 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype105, _vtype106, _size104 = iprot:readMapBegin() 
+        local _ktype105, _vtype106, _size104 = iprot:readMapBegin()
         for _i=1,_size104 do
           local _key108 = iprot:readString()
           local _val109 = iprot:readString()
@@ -829,7 +829,7 @@ function UploadUrls_args:read(iprot)
     elseif fid == 3 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype118, _vtype119, _size117 = iprot:readMapBegin() 
+        local _ktype118, _vtype119, _size117 = iprot:readMapBegin()
         for _i=1,_size117 do
           local _key121 = iprot:readString()
           local _val122 = iprot:readString()
@@ -947,7 +947,7 @@ function UploadUserMentions_args:read(iprot)
     elseif fid == 3 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype132, _vtype133, _size131 = iprot:readMapBegin() 
+        local _ktype132, _vtype133, _size131 = iprot:readMapBegin()
         for _i=1,_size131 do
           local _key135 = iprot:readString()
           local _val136 = iprot:readString()

--- a/socialNetwork/openshift/nginx-thrift-config/gen-lua/social_network_PostStorageService.lua
+++ b/socialNetwork/openshift/nginx-thrift-config/gen-lua/social_network_PostStorageService.lua
@@ -176,7 +176,7 @@ function StorePost_args:read(iprot)
     elseif fid == 3 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype141, _vtype142, _size140 = iprot:readMapBegin() 
+        local _ktype141, _vtype142, _size140 = iprot:readMapBegin()
         for _i=1,_size140 do
           local _key144 = iprot:readString()
           local _val145 = iprot:readString()
@@ -283,7 +283,7 @@ function ReadPost_args:read(iprot)
     elseif fid == 3 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype149, _vtype150, _size148 = iprot:readMapBegin() 
+        local _ktype149, _vtype150, _size148 = iprot:readMapBegin()
         for _i=1,_size148 do
           local _key152 = iprot:readString()
           local _val153 = iprot:readString()

--- a/socialNetwork/openshift/nginx-thrift-config/gen-lua/social_network_UrlShortenService.lua
+++ b/socialNetwork/openshift/nginx-thrift-config/gen-lua/social_network_UrlShortenService.lua
@@ -187,7 +187,7 @@ function UploadUrls_args:read(iprot)
     elseif fid == 3 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype256, _vtype257, _size255 = iprot:readMapBegin() 
+        local _ktype256, _vtype257, _size255 = iprot:readMapBegin()
         for _i=1,_size255 do
           local _key259 = iprot:readString()
           local _val260 = iprot:readString()
@@ -326,7 +326,7 @@ function GetExtendedUrls_args:read(iprot)
     elseif fid == 3 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype276, _vtype277, _size275 = iprot:readMapBegin() 
+        local _ktype276, _vtype277, _size275 = iprot:readMapBegin()
         for _i=1,_size275 do
           local _key279 = iprot:readString()
           local _val280 = iprot:readString()

--- a/socialNetwork/openshift/nginx-thrift-config/gen-lua/social_network_UserMentionService.lua
+++ b/socialNetwork/openshift/nginx-thrift-config/gen-lua/social_network_UserMentionService.lua
@@ -125,7 +125,7 @@ function UploadUserMentions_args:read(iprot)
     elseif fid == 3 then
       if ftype == TType.MAP then
         self.carrier = {}
-        local _ktype242, _vtype243, _size241 = iprot:readMapBegin() 
+        local _ktype242, _vtype243, _size241 = iprot:readMapBegin()
         for _i=1,_size241 do
           local _key245 = iprot:readString()
           local _val246 = iprot:readString()

--- a/socialNetwork/openshift/nginx-thrift-config/nginx.conf
+++ b/socialNetwork/openshift/nginx-thrift-config/nginx.conf
@@ -8,7 +8,7 @@ worker_processes  16;
 error_log  logs/error.log warn;
 
 # Checklist: Make sure that worker_connections * worker_processes
-# is greater than the total connections between the client and Nginx. 
+# is greater than the total connections between the client and Nginx.
 events {
   worker_connections  1024;
 }

--- a/socialNetwork/openshift/nginx-thrift.yaml
+++ b/socialNetwork/openshift/nginx-thrift.yaml
@@ -32,7 +32,7 @@ spec:
       app: nginx-thrift
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: nginx-thrift
       name: nginx-thrift
@@ -40,7 +40,7 @@ spec:
       containers:
       - name: nginx-thrift
         image: yg397/openresty-thrift:xenial
-        ports: 
+        ports:
         - containerPort: 8080
         volumeMounts:
         - mountPath: /usr/local/openresty/nginx/lua-scripts

--- a/socialNetwork/openshift/post-storage-memcached.yaml
+++ b/socialNetwork/openshift/post-storage-memcached.yaml
@@ -30,7 +30,7 @@ spec:
       app: post-storage-memcached
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: post-storage-memcached
       name: post-storage-memcached

--- a/socialNetwork/openshift/post-storage-mongodb.yaml
+++ b/socialNetwork/openshift/post-storage-mongodb.yaml
@@ -30,7 +30,7 @@ spec:
       app: post-storage-mongodb
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: post-storage-mongodb
       name: post-storage-mongodb

--- a/socialNetwork/openshift/post-storage-service.yaml
+++ b/socialNetwork/openshift/post-storage-service.yaml
@@ -30,7 +30,7 @@ spec:
       app: post-storage-service
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: post-storage-service
       name: post-storage-service
@@ -39,7 +39,7 @@ spec:
       - name: post-storage-service
         image: yg397/social-network-microservices
         command: ["PostStorageService"]
-        ports: 
+        ports:
         - containerPort: 9090
         volumeMounts:
           - mountPath: /social-network-microservices/config/jaeger-config.yml

--- a/socialNetwork/openshift/scripts/build-docker-img.sh
+++ b/socialNetwork/openshift/scripts/build-docker-img.sh
@@ -47,7 +47,7 @@ TOKEN=$(oc whoami -t)
 USER=$(oc whoami)
 oc project $PROJECT
 oc registry login \
-  --insecure=true --skip-check -z default --token=$TOKEN $REGISTRY 
+  --insecure=true --skip-check -z default --token=$TOKEN $REGISTRY
 $EXEC login -u $USER -p $TOKEN $REGISTRY
 
 # ENTER IN THE SOCIAL-NETWORK ROOT FOLDER

--- a/socialNetwork/openshift/scripts/configmaps/create-nginx-thrift-configmap.sh
+++ b/socialNetwork/openshift/scripts/configmaps/create-nginx-thrift-configmap.sh
@@ -25,4 +25,4 @@ oc create cm nginx-thrift        --from-file=nginx-thrift-config/nginx.conf -n $
 
 
 # nginx-thrift has a dependency on the ConfigMap nginx-thrift-jaeger, which
-# is created by the script `create-jaeger-configmap.sh` 
+# is created by the script `create-jaeger-configmap.sh`

--- a/socialNetwork/openshift/scripts/configmaps/update-nginx-thrift-configmap.sh
+++ b/socialNetwork/openshift/scripts/configmaps/update-nginx-thrift-configmap.sh
@@ -22,5 +22,5 @@ oc create cm nginx-thrift-luascripts-wrk2-api-user-timeline --from-file=nginx-th
 oc create cm nginx-thrift        --from-file=nginx-thrift-config/nginx.conf     -n ${NS}    --dry-run --save-config -o yaml | oc apply -f - -n ${NS}
 
 # nginx-thrift has a dependency on the ConfigMap nginx-thrift-jaeger, which
-# is created by the script `create-jaeger-configmap.sh` 
+# is created by the script `create-jaeger-configmap.sh`
 # oc create cm nginx-thrift-jaeger --from-file=nginx-thrift-config/jaeger-config.json --dry-run --save-config -o yaml | oc apply -f -

--- a/socialNetwork/openshift/scripts/deploy-all-services-and-configurations.sh
+++ b/socialNetwork/openshift/scripts/deploy-all-services-and-configurations.sh
@@ -7,7 +7,7 @@ oc create namespace ${NS}
 oc adm policy add-scc-to-user anyuid -z default -n ${NS}
 oc adm policy add-scc-to-user privileged -z default -n ${NS}
 
-./scripts/create-all-configmap.sh 
+./scripts/create-all-configmap.sh
 
 # The following script optionally creates local docker images suitable for local customization.
 # ./scripts/build-docker-img.sh

--- a/socialNetwork/openshift/social-graph-mongodb.yaml
+++ b/socialNetwork/openshift/social-graph-mongodb.yaml
@@ -30,7 +30,7 @@ spec:
       app: social-graph-mongodb
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: social-graph-mongodb
       name: social-graph-mongodb

--- a/socialNetwork/openshift/social-graph-redis.yaml
+++ b/socialNetwork/openshift/social-graph-redis.yaml
@@ -30,7 +30,7 @@ spec:
       app: social-graph-redis
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: social-graph-redis
       name: social-graph-redis

--- a/socialNetwork/openshift/social-graph-service.yaml
+++ b/socialNetwork/openshift/social-graph-service.yaml
@@ -30,7 +30,7 @@ spec:
       app: social-graph-service
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: social-graph-service
       name: social-graph-service

--- a/socialNetwork/openshift/text-service.yaml
+++ b/socialNetwork/openshift/text-service.yaml
@@ -30,7 +30,7 @@ spec:
       app: text-service
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: text-service
       name: text-service

--- a/socialNetwork/openshift/ubuntu-client.yaml
+++ b/socialNetwork/openshift/ubuntu-client.yaml
@@ -15,7 +15,7 @@ spec:
       app: ubuntu-client
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: ubuntu-client
       name: ubuntu-client

--- a/socialNetwork/openshift/unique-id-service.yaml
+++ b/socialNetwork/openshift/unique-id-service.yaml
@@ -30,7 +30,7 @@ spec:
       app: unique-id-service
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: unique-id-service
       name: unique-id-service

--- a/socialNetwork/openshift/url-shorten-memcached.yaml
+++ b/socialNetwork/openshift/url-shorten-memcached.yaml
@@ -30,7 +30,7 @@ spec:
       app: url-shorten-memcached
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: url-shorten-memcached
       name: url-shorten-memcached

--- a/socialNetwork/openshift/url-shorten-mongodb.yaml
+++ b/socialNetwork/openshift/url-shorten-mongodb.yaml
@@ -30,7 +30,7 @@ spec:
       app: url-shorten-mongodb
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: url-shorten-mongodb
       name: url-shorten-mongodb

--- a/socialNetwork/openshift/url-shorten-service.yaml
+++ b/socialNetwork/openshift/url-shorten-service.yaml
@@ -30,7 +30,7 @@ spec:
       app: url-shorten-service
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: url-shorten-service
       name: url-shorten-service

--- a/socialNetwork/openshift/user-memcached.yaml
+++ b/socialNetwork/openshift/user-memcached.yaml
@@ -30,7 +30,7 @@ spec:
       app: user-memcached
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: user-memcached
       name: user-memcached

--- a/socialNetwork/openshift/user-mention-service.yaml
+++ b/socialNetwork/openshift/user-mention-service.yaml
@@ -30,7 +30,7 @@ spec:
       app: user-mention-service
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: user-mention-service
       name: user-mention-service

--- a/socialNetwork/openshift/user-mongodb.yaml
+++ b/socialNetwork/openshift/user-mongodb.yaml
@@ -30,7 +30,7 @@ spec:
       app: user-mongodb
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: user-mongodb
       name: user-mongodb

--- a/socialNetwork/openshift/user-service.yaml
+++ b/socialNetwork/openshift/user-service.yaml
@@ -30,7 +30,7 @@ spec:
       app: user-service
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: user-service
       name: user-service

--- a/socialNetwork/openshift/user-timeline-mongodb.yaml
+++ b/socialNetwork/openshift/user-timeline-mongodb.yaml
@@ -30,7 +30,7 @@ spec:
       app: user-timeline-mongodb
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: user-timeline-mongodb
       name: user-timeline-mongodb

--- a/socialNetwork/openshift/user-timeline-redis.yaml
+++ b/socialNetwork/openshift/user-timeline-redis.yaml
@@ -30,7 +30,7 @@ spec:
       app: user-timeline-redis
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: user-timeline-redis
       name: user-timeline-redis

--- a/socialNetwork/openshift/user-timeline-service.yaml
+++ b/socialNetwork/openshift/user-timeline-service.yaml
@@ -30,7 +30,7 @@ spec:
       app: user-timeline-service
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: user-timeline-service
       name: user-timeline-service

--- a/socialNetwork/openshift/write-home-timeline-rabbitmq.yaml
+++ b/socialNetwork/openshift/write-home-timeline-rabbitmq.yaml
@@ -37,7 +37,7 @@ spec:
       app: write-home-timeline-rabbitmq
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: write-home-timeline-rabbitmq
       name: write-home-timeline-rabbitmq

--- a/socialNetwork/openshift/write-home-timeline-service.yaml
+++ b/socialNetwork/openshift/write-home-timeline-service.yaml
@@ -32,7 +32,7 @@ spec:
       app: write-home-timeline-service
   template:
     metadata:
-      labels: 
+      labels:
         death-star-project: social-network
         app: write-home-timeline-service
       name: write-home-timeline-service

--- a/socialNetwork/social_network.thrift
+++ b/socialNetwork/social_network.thrift
@@ -141,7 +141,7 @@ service ComposePostService {
     2: string username,
     3: i64 user_id,
     4: string text,
-    5: list<i64> media_ids, 
+    5: list<i64> media_ids,
     6: list<string> media_types,
     7: PostType post_type,
     8: map<string, string> carrier

--- a/socialNetwork/src/ClientPool.h
+++ b/socialNetwork/src/ClientPool.h
@@ -81,7 +81,7 @@ template<class TClient>
 TClient * ClientPool<TClient>::Pop() {
   TClient * client = nullptr;
   {
-    std::unique_lock<std::mutex> cv_lock(_mtx); 
+    std::unique_lock<std::mutex> cv_lock(_mtx);
     while (_pool.size() == 0 && _curr_pool_size == _max_pool_size) {
       // Create a new a client if current pool size is less than
       // the max pool size.
@@ -105,7 +105,7 @@ TClient * ClientPool<TClient>::Pop() {
     }
   cv_lock.unlock();
   } // cv_lock(_mtx)
-  
+
 
   if (client) {
     try {
@@ -114,7 +114,7 @@ TClient * ClientPool<TClient>::Pop() {
       LOG(error) << "Failed to connect " + _client_type;
       Remove(client);
       throw;
-    }    
+    }
   }
   return client;
 }

--- a/socialNetwork/src/UserTimelineService/UserTimelineHandler.h
+++ b/socialNetwork/src/UserTimelineService/UserTimelineHandler.h
@@ -137,10 +137,10 @@ void UserTimelineHandler::WriteUserTimeline(
       "write_user_timeline_redis_update_client",
       {opentracing::ChildOf(&span->context())});
   try {
-    if (_redis_client_pool) 
+    if (_redis_client_pool)
       _redis_client_pool->zadd(std::to_string(user_id), std::to_string(post_id),
                               timestamp, UpdateType::NOT_EXIST);
-    else 
+    else
       _redis_cluster_client_pool->zadd(std::to_string(user_id), std::to_string(post_id),
                               timestamp, UpdateType::NOT_EXIST);
 

--- a/socialNetwork/src/tracing.h
+++ b/socialNetwork/src/tracing.h
@@ -57,7 +57,7 @@ void SetUpTracer(
 
   // Enable local Jaeger agent, by prepending the service name to the default
   // Jaeger agent's hostname
-  // configYAML["reporter"]["localAgentHostPort"] = service + "-" + 
+  // configYAML["reporter"]["localAgentHostPort"] = service + "-" +
   //     configYAML["reporter"]["localAgentHostPort"].as<std::string>();
 
   auto config = jaegertracing::Config::parse(configYAML);
@@ -78,8 +78,8 @@ void SetUpTracer(
       sleep(1);
     }
   }
-  
-  
+
+
 }
 
 

--- a/socialNetwork/test/TestComposePostE2E.py
+++ b/socialNetwork/test/TestComposePostE2E.py
@@ -21,12 +21,12 @@ def main():
   media_types = ["png", "png", "png", "png"]
   media_ids = [1, 2, 3, 4]
   creator = "username_0"
-  
+
   text_socket = TSocket.TSocket("ath-8.ece.cornell.edu", 10007)
   text_transport = TTransport.TFramedTransport(text_socket)
   text_protocol = TBinaryProtocol.TBinaryProtocol(text_transport)
   text_client = TextService.Client(text_protocol)
-  text_transport.open() 
+  text_transport.open()
   text_client.UploadText(req_id, text, {})
   text_transport.close()
 
@@ -53,8 +53,8 @@ def main():
   post_id_transport.open()
   post_id_client.UploadUniqueId(req_id, post_tyoe, {})
   post_id_transport.close()
-  
-  
+
+
 
 if __name__ == '__main__':
   try:

--- a/socialNetwork/wrk2/README.md
+++ b/socialNetwork/wrk2/README.md
@@ -13,8 +13,8 @@
   Therefore, I fundamentally changed the load generator to be
   open-loop; requests are sent out according to the schedule no matter what. Any
   traffic on the server side will be directly refected in the real latency,
-  so we don't have to approximate that like wrk2. Latency reporting is the same as 
-  wrk. 
+  so we don't have to approximate that like wrk2. Latency reporting is the same as
+  wrk.
 
   Some other features added:
   1. add -P parameter to print end-to-end latency of every request to files. The
@@ -131,11 +131,11 @@
      99.990%   12.45ms
      99.999%   12.50ms
     100.000%   12.50ms
-  
+
     Detailed Percentile spectrum:
          Value   Percentile   TotalCount 1/(1-Percentile)
-         
-         0.921     0.000000            1         1.00 
+
+         0.921     0.000000            1         1.00
          4.053     0.100000         3951         1.11
          4.935     0.200000         7921         1.25
          5.627     0.300000        11858         1.43
@@ -369,10 +369,10 @@ A note about wrk2's latency measurement technique:
   the "uncorrected" percentile distributions measured during wrk2 runs.
   (The "uncorrected" distributions are labeled with "CO", for Coordinated
   Omission)
-  
+
   ![CO example]
-  
-  These differences can be seen in detail in the output provided when 
+
+  These differences can be seen in detail in the output provided when
   the --u_latency flag is used. For example, the output below demonstrates
   the difference in recorded latency distribution for two runs:
 
@@ -395,7 +395,7 @@ A note about wrk2's latency measurement technique:
 Example 1: [short, non-noisy run (~11msec worst observed latency)]:
 
     wrk -t2 -c100 -d30s -R2000 --u_latency http://127.0.0.1:80/index.html
- 
+
     Running 30s test @ http://127.0.0.1:80/index.html
       2 threads and 100 connections
       Thread calibration: mean lat.: 9319 usec, rate sampling interval: 21 msec
@@ -412,10 +412,10 @@ Example 1: [short, non-noisy run (~11msec worst observed latency)]:
      99.990%   11.29ms
      99.999%   11.32ms
     100.000%   11.32ms
-   
+
       Detailed Percentile spectrum:
            Value   Percentile   TotalCount 1/(1-Percentile)
- 
+
            0.677     0.000000            1         1.00
            3.783     0.100000         3952         1.11
            4.643     0.200000         7924         1.25
@@ -499,9 +499,9 @@ Example 1: [short, non-noisy run (~11msec worst observed latency)]:
     #[Max     =       11.312, Total count    =        39500]
     #[Buckets =           27, SubBuckets     =         2048]
     ----------------------------------------------------------
- 
+
       Latency Distribution (HdrHistogram - Uncorrected Latency (measured without taking delayed starts into account))
-     50.000%    2.68ms 
+     50.000%    2.68ms
      75.000%    3.71ms
      90.000%    4.47ms
      99.000%    5.43ms
@@ -509,10 +509,10 @@ Example 1: [short, non-noisy run (~11msec worst observed latency)]:
      99.990%    6.99ms
      99.999%    7.01ms
     100.000%    7.01ms
- 
+
       Detailed Percentile spectrum:
            Value   Percentile   TotalCount 1/(1-Percentile)
- 
+
            0.264     0.000000            1         1.00
            1.111     0.100000         3954         1.11
            1.589     0.200000         7909         1.25
@@ -575,7 +575,7 @@ Example 1: [short, non-noisy run (~11msec worst observed latency)]:
            6.951     0.999707        39489      3413.33
            6.979     0.999756        39491      4096.00
            6.983     0.999780        39494      4551.11
-           6.983     0.999805        39494      5120.00  
+           6.983     0.999805        39494      5120.00
            6.983     0.999829        39494      5851.43
            6.987     0.999854        39496      6826.67
            6.987     0.999878        39496      8192.00
@@ -605,9 +605,9 @@ Example 1: [short, non-noisy run (~11msec worst observed latency)]:
 ************************************************************************
 
 Example 2: [1.4 second ^Z artifact introduced on the httpd server]:
- 
+
     wrk -t2 -c100 -d30s -R2000 --u_latency http://127.0.0.1:80/index.html
- 
+
     Running 30s test @ http://127.0.0.1:80/index.html
       2 threads and 100 connections
       Thread calibration: mean lat.: 108237 usec, rate sampling interval: 1021 msec
@@ -624,10 +624,10 @@ Example 2: [1.4 second ^Z artifact introduced on the httpd server]:
      99.990%    1.42s
      99.999%    1.42s
     100.000%    1.42s
- 
+
       Detailed Percentile spectrum:
            Value   Percentile   TotalCount 1/(1-Percentile)
- 
+
            1.317     0.000000            1         1.00
            5.011     0.100000         3954         1.11
            6.215     0.200000         7903         1.25
@@ -709,9 +709,9 @@ Example 2: [1.4 second ^Z artifact introduced on the httpd server]:
            4.423     0.850000        33599         6.67
            4.587     0.875000        34564         8.00
            4.735     0.887500        35057         8.89
-           4.871     0.900000        35560        10.00 
+           4.871     0.900000        35560        10.00
            4.975     0.912500        36051        11.43
-           5.063     0.925000        36543        13.33 
+           5.063     0.925000        36543        13.33
            5.143     0.937500        37039        16.00
            5.187     0.943750        37282        17.78
            5.239     0.950000        37533        20.00

--- a/socialNetwork/wrk2/scripts/multiplepaths.lua
+++ b/socialNetwork/wrk2/scripts/multiplepaths.lua
@@ -51,7 +51,7 @@ request = function()
       counter = 0
     end
 --    return wrk.format(nil, path)
-    
+
 --    depth = tonumber(args[1]) or 1
     local r = {}
     for i=1, depth do

--- a/socialNetwork/wrk2/scripts/social-network/mixed-workload.lua
+++ b/socialNetwork/wrk2/scripts/social-network/mixed-workload.lua
@@ -96,7 +96,7 @@ local function read_home_timeline()
     local user_id = tostring(math.random(1, 962))
     local start = tostring(math.random(0, 100))
     local stop = tostring(start + 10)
-  
+
     local args = "user_id=" .. user_id .. "&start=" .. start .. "&stop=" .. stop
     local method = "GET"
     local headers = {}
@@ -110,13 +110,13 @@ request = function()
     local read_home_timeline_ratio = 0.60
     local read_user_timeline_ratio = 0.30
     local compose_post_ratio       = 0.10
-  
+
     local coin = math.random()
     if coin < read_home_timeline_ratio then
       return read_home_timeline()
     elseif coin < read_home_timeline_ratio + read_user_timeline_ratio then
       return read_user_timeline()
-    else 
+    else
       return compose_post()
     end
   end

--- a/socialNetwork/wrk2/src/ae_kqueue.c
+++ b/socialNetwork/wrk2/src/ae_kqueue.c
@@ -54,8 +54,8 @@ static int aeApiCreate(aeEventLoop *eventLoop) {
         return -1;
     }
     eventLoop->apidata = state;
-    
-    return 0;    
+
+    return 0;
 }
 
 static void aeApiFree(aeEventLoop *eventLoop) {
@@ -69,7 +69,7 @@ static void aeApiFree(aeEventLoop *eventLoop) {
 static int aeApiAddEvent(aeEventLoop *eventLoop, int fd, int mask) {
     aeApiState *state = eventLoop->apidata;
     struct kevent ke;
-    
+
     if (mask & AE_READABLE) {
         EV_SET(&ke, fd, EVFILT_READ, EV_ADD, 0, 0, NULL);
         if (kevent(state->kqfd, &ke, 1, NULL, 0, NULL) == -1) return -1;
@@ -112,16 +112,16 @@ static int aeApiPoll(aeEventLoop *eventLoop, struct timeval *tvp) {
 
     if (retval > 0) {
         int j;
-        
+
         numevents = retval;
         for(j = 0; j < numevents; j++) {
             int mask = 0;
             struct kevent *e = state->events+j;
-            
+
             if (e->filter == EVFILT_READ) mask |= AE_READABLE;
             if (e->filter == EVFILT_WRITE) mask |= AE_WRITABLE;
-            eventLoop->fired[j].fd = e->ident; 
-            eventLoop->fired[j].mask = mask;           
+            eventLoop->fired[j].fd = e->ident;
+            eventLoop->fired[j].mask = mask;
         }
     }
     return numevents;

--- a/socialNetwork/wrk2/src/http_parser.c
+++ b/socialNetwork/wrk2/src/http_parser.c
@@ -124,7 +124,7 @@ do {                                                                 \
     FOR##_mark = NULL;                                               \
   }                                                                  \
 } while (0)
-  
+
 /* Run the data callback FOR and consume the current byte */
 #define CALLBACK_DATA(FOR)                                           \
     CALLBACK_DATA_(FOR, p - FOR##_mark, p - data + 1)

--- a/socialNetwork/wrk2/src/http_parser.h
+++ b/socialNetwork/wrk2/src/http_parser.h
@@ -144,7 +144,7 @@ enum flags
 
 
 /* Map for errno-related constants
- * 
+ *
  * The provided argument should be a macro that takes 2 arguments.
  */
 #define HTTP_ERRNO_MAP(XX)                                           \

--- a/socialNetwork/wrk2/src/wrk.c
+++ b/socialNetwork/wrk2/src/wrk.c
@@ -200,7 +200,7 @@ int main(int argc, char **argv) {
 
         hdr_add(latency_histogram, t->latency_histogram);
         hdr_add(real_latency_histogram, t->real_latency_histogram);
-        
+
         if (cfg.print_all_responses) {
             char filename[10] = {0};
             sprintf(filename, "%" PRIu64 ".txt", i);
@@ -272,7 +272,7 @@ void *thread_main(void *arg) {
     if (!cfg.dynamic) {
         script_request(thread->L, &request, &length);
     }
-    
+
     thread->ff = NULL;
     if ((cfg.print_realtime_latency) && (thread->tid == 0)) {
         char filename[50];
@@ -523,7 +523,7 @@ static uint64_t usec_to_next_send(connection *c) {
         ++c->estimate;
         c->thread_next += gen_next(c);
     }
-    if ((c->thread_next) > now) 
+    if ((c->thread_next) > now)
         return c->thread_next - now;
     else
         return 0;
@@ -572,10 +572,10 @@ static int response_complete(http_parser *parser) {
         uint64_t actual_latency_timing = now - c->actual_latency_start[c->complete & MAXO];
         hdr_record_value(thread->latency_histogram, actual_latency_timing);
         hdr_record_value(thread->real_latency_histogram, actual_latency_timing);
-    
+
         thread->monitored++;
         thread->accum_latency += actual_latency_timing;
-        if (thread->monitored == thread->target) {       
+        if (thread->monitored == thread->target) {
             if (cfg.print_realtime_latency && thread->tid == 0) {
                 fprintf(thread->ff, "%" PRId64 "\n", hdr_value_at_percentile(thread->real_latency_histogram, 99));
                 fflush(thread->ff);
@@ -584,7 +584,7 @@ static int response_complete(http_parser *parser) {
             thread->accum_latency = 0;
             hdr_reset(thread->real_latency_histogram);
         }
-        if (cfg.print_all_responses && ((thread->complete) < MAXL)) 
+        if (cfg.print_all_responses && ((thread->complete) < MAXL))
             raw_latency[thread->tid][thread->complete] = actual_latency_timing;
     }
 
@@ -759,13 +759,13 @@ static int parse_args(struct config *cfg, char **url, struct http_parser_url *pa
                 if (scan_metric(optarg, &cfg->connections)) return -1;
                 break;
             case 'D':
-                if (!strcmp(optarg, "fixed"))  
+                if (!strcmp(optarg, "fixed"))
                     cfg->dist = 0;
-                if (!strcmp(optarg, "exp")) 
+                if (!strcmp(optarg, "exp"))
                     cfg->dist = 1;
-                if (!strcmp(optarg, "norm")) 
+                if (!strcmp(optarg, "norm"))
                     cfg->dist = 2;
-                if (!strcmp(optarg, "zipf")) 
+                if (!strcmp(optarg, "zipf"))
                     cfg->dist = 3;
                 break;
             case 'd':


### PR DESCRIPTION
This MR makes several improvements to the Dockerfiles. It also includes #134 and #133.

* Detect the number of CPUs automatically such that the number of make jobs corresponds to the number of CPUs of the host.
* Turn the main Dockerfile into a multi-stage build. This reduces the image size from 1.5GB to 300MB.
* Exclude irrelevant files from the Docker build context. This speeds up building images and makes rebuilding unnecessary when excluded files have changed.
* Add a new Docker file that allows to run `wrk` and `init_social_graph.py`.

@gy1005: Please let me know if you'd like me to do any changes before merging.