### PR TITLE
hotel: workaround of TLS cert expire issue

### DIFF
--- a/hotelReservation/Dockerfile
+++ b/hotelReservation/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.9
 
+RUN git config --global http.sslverify false
 COPY . /go/src/github.com/harlow/go-micro-services
 WORKDIR /go/src/github.com/harlow/go-micro-services
 RUN go get gopkg.in/mgo.v2


### PR DESCRIPTION
Starting from Sep 30th 2021, Let's Encrypts previous root certificate
expires, which causes the hotelReservation docker image build process
to fail.

Since Debian stretch release has not provided the latest ca-certificate
package yet, we have to work-around this TLS cert expire issue by not
checking the server certificate's validity.

Fixes issue #142.

Signed-off-by: Lianhao Lu <lianhao.lu@intel.com>