### PR TITLE
Golang update

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,3 @@ If you use this benchmark suite in your work, we ask that you please cite the pa
 ## Beta-testing
 
 If you are interested in joining the beta-testing group for DeathStarBench, send us an email at: <microservices-bench-L@list.cornell.edu>
- 

--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ If you use this benchmark suite in your work, we ask that you please cite the pa
 ## Beta-testing
 
 If you are interested in joining the beta-testing group for DeathStarBench, send us an email at: <microservices-bench-L@list.cornell.edu>
+ 

--- a/hotelReservation/Dockerfile
+++ b/hotelReservation/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9
+FROM golang:1.17.3
 
 RUN git config --global http.sslverify false
 COPY . /go/src/github.com/harlow/go-micro-services
@@ -6,4 +6,6 @@ WORKDIR /go/src/github.com/harlow/go-micro-services
 RUN go get gopkg.in/mgo.v2
 RUN go get github.com/bradfitz/gomemcache/memcache
 RUN go get github.com/google/uuid
+RUN go mod init
+RUN go mod vendor
 RUN go install -ldflags="-s -w" ./cmd/...


### PR DESCRIPTION
The Hotel Reservation application requires Golang to be updated to successfully prepare a Docker image.  Root cause: Golang 1.9 is using an outdated certificate.