### PR TITLE
MediaMicroservice: Update Luarocks and make command improvement

### DIFF
--- a/mediaMicroservices/docker/openresty-thrift/xenial/Dockerfile
+++ b/mediaMicroservices/docker/openresty-thrift/xenial/Dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="Yu Gan <yg397@cornell.edu>"
 
 # Docker Build Arguments
 ARG RESTY_VERSION="1.15.8.1rc1"
-ARG RESTY_LUAROCKS_VERSION="2.4.4"
+ARG RESTY_LUAROCKS_VERSION="3.5.0"
 ARG RESTY_OPENSSL_VERSION="1.1.0j"
 ARG RESTY_PCRE_VERSION="8.42"
 ARG JAEGER_TRACING_VERSION="0.4.2"
@@ -109,8 +109,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
              -DBUILD_STATIC_LIBS=OFF \
              -DBUILD_TESTING=OFF \
        .. \
-    && make \
-    && make install \
+    && make -j$(nproc) \
+    && make -j$(nproc) install \
     && cd /tmp \
     && rm -rf opentracing-cpp-${OPENTRACING_CPP_VERSION}.tar.gz \
               opentracing-cpp-${OPENTRACING_CPP_VERSION} \
@@ -153,7 +153,7 @@ RUN cd /usr/local \
         pcre-${RESTY_PCRE_VERSION}.tar.gz pcre-${RESTY_PCRE_VERSION}
 
 RUN cd /tmp \
-    && curl -fSL https://github.com/luarocks/luarocks/archive/${RESTY_LUAROCKS_VERSION}.tar.gz -o luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
+    && curl -fSL  https://luarocks.github.io/luarocks/releases/luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz -o luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
     && tar xzf luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
     && cd luarocks-${RESTY_LUAROCKS_VERSION} \
     && ./configure \
@@ -195,8 +195,8 @@ RUN cd /usr/local/openresty/lualib/thrift/src \
     && cd cmake-build \
     && cmake -DCMAKE_BUILD_TYPE=Release \
        .. \
-    && make \
-    && make install
+    && make -j$(nproc) \
+    && make -j$(nproc) install
 #    && cd /tmp
 #    && rm -rf lua-bridge-tracer
 


### PR DESCRIPTION
Luarocks fails on version 2.4.4 installation and this PR fixes the issue.

Output error:
`Step 41/45 : RUN luarocks install long     && luarocks install lua-resty-jwt     && ldconfig
 ---> Running in ea0a00f2f0d4
Warning: The directory '/root/.cache/luarocks' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing /usr/local/openresty/luajit/bin/luarocks with sudo, you may want sudo's -H flag.
Installing https://luarocks.org/long-2.0.0-0.src.rock
Missing dependencies for long 2.0.0-0:
   bit32 <= 5.3.2-0 (not installed)

long 2.0.0-0 depends on bit32 <= 5.3.2-0 (not installed)
Installing https://luarocks.org/bit32-5.3.0-1.src.rock
In file included from c-api/compat-5.2.c:6:0,
                 from lbitlib.c:17:
c-api/compat-5.2.h:149:0: warning: "luaL_newlib" redefined
 #define luaL_newlib(L, l) \
 ^
In file included from lbitlib.c:12:0:
/usr/local/openresty/luajit/include/luajit-2.1/lauxlib.h:125:0: note: this is the location of the previous definition
 #define luaL_newlib(L, l) (luaL_newlibtable(L, l), luaL_setfuncs(L, l, 0))
 ^
gcc -O2 -fPIC -I/usr/local/openresty/luajit/include/luajit-2.1 -c lbitlib.c -o lbitlib.o -Ic-api
gcc -shared -o bit32.so -L/usr/local/openresty/luajit/lib lbitlib.o
No existing manifest. Attempting to rebuild...
bit32 5.3.0-1 is now installed in /usr/local/openresty/luajit (license: MIT/X11)

long 2.0.0-0 is now installed in /usr/local/openresty/luajit (license: Apache 2.0)

Warning: The directory '/root/.cache/luarocks' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing /usr/local/openresty/luajit/bin/luarocks with sudo, you may want sudo's -H flag.
Installing https://luarocks.org/lua-resty-jwt-0.2.3-0.src.rock

Error: Rockspec format 3.0 is not supported, please upgrade LuaRocks.
The command '/bin/sh -c luarocks install long     && luarocks install lua-resty-jwt     && ldconfig' returned a non-zero code: 1
`