### PR TITLE
Socialnetwork helm chart fix

### DIFF
--- a/socialNetwork/docker/media-frontend/xenial/xenial-lua/Dockerfile
+++ b/socialNetwork/docker/media-frontend/xenial/xenial-lua/Dockerfile
@@ -1,3 +1,0 @@
-FROM yg397/media-frontend:xenial
-
-COPY ../../../../media-frontend/lua-scripts/ /usr/local/openresty/nginx/lua-scripts

--- a/socialNetwork/docker/media-frontend/xenial/xenial-lua/Makefile
+++ b/socialNetwork/docker/media-frontend/xenial/xenial-lua/Makefile
@@ -1,3 +1,0 @@
-
-build:
-	docker build . -t yg397/media-frontend:xenial

--- a/socialNetwork/docker/openresty-thrift/xenial/xenial-lua/Dockerfile
+++ b/socialNetwork/docker/openresty-thrift/xenial/xenial-lua/Dockerfile
@@ -1,7 +1,0 @@
-FROM yg397/openresty-thrift:xenial
-
-COPY ../../../../gen-lua /gen-lua
-COPY ../../lua-thrift /usr/local/openresty/lualib/thrift
-
-COPY ../../../../nginx-web-server/lua-scripts /usr/local/openresty/nginx/lua-scripts
-COPY ../../../../nginx-web-server/pages /usr/local/openresty/nginx/pages

--- a/socialNetwork/docker/openresty-thrift/xenial/xenial-lua/Makefile
+++ b/socialNetwork/docker/openresty-thrift/xenial/xenial-lua/Makefile
@@ -1,3 +1,0 @@
-
-build:
-	docker build . -t yg397/openresty-thrift:xenial

--- a/socialNetwork/helm-chart/README.md
+++ b/socialNetwork/helm-chart/README.md
@@ -28,10 +28,7 @@ All mongo, nginx and redis pods will use the same respective config file from th
 In order to override a given value for a config file, a new config (with the new content) must be placed under the same filename in the given microservice template.
 
 ## Custom images ##
-Modified lua scripts must be put inside the following images:
-- openresty-thrift:xenial
-- media-frontend:xenial
-
+`nginx-thrift` and `media-frontend` services require mounted lua-scripts (and other files). For this reason, in both of these pods, there is an init container added that pulls the rquired files from the public DSB repository and mounts them in the right path before the container is started.
 
 ### Changes to config files ###
 In nginx config file, both in `nginx-thrift` and `media-frontend` pods, resolver is set to a value retrieved from global values under `resolverName`. It is set to `kube-dns.kube-system.svc.cluster.local`. <br />

--- a/socialNetwork/helm-chart/socialnetwork/charts/media-frontend/templates/deployment.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/media-frontend/templates/deployment.yaml
@@ -1,2 +1,2 @@
-{{ include "socialnetwork.templates.baseDeployment" . }}
+{{ include "socialnetwork.templates.baseNginxDeployment" . }}
  

--- a/socialNetwork/helm-chart/socialnetwork/charts/media-frontend/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/media-frontend/values.yaml
@@ -13,7 +13,24 @@ container:
   env:
   - name: fqdn_suffix
     value: ".{{ .Release.Namespace }}.svc.cluster.local"
-      
+  volumeMounts:
+    - name: lua-scripts
+      mountPath: /usr/local/openresty/nginx/lua-scripts
+
+initContainer:
+  image: alpine/git
+  imageVersion: latest
+  name: alpine-container
+  volumeMounts:
+  - name: lua-scripts
+    mountPath: /lua-scripts
+  command: "/bin/sh" 
+  args: ["-c", "git clone https://github.com/delimitrou/DeathStarBench.git /DeathStarBench &&
+            cp -r /DeathStarBench/socialNetwork/media-frontend/lua-scripts/* /lua-scripts/"]
+
+volumes:
+  - name: lua-scripts
+
 configMaps:
   - name: nginx.conf
     mountPath: /usr/local/openresty/nginx/conf/nginx.conf

--- a/socialNetwork/helm-chart/socialnetwork/charts/nginx-thrift/templates/deployment.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/nginx-thrift/templates/deployment.yaml
@@ -1,2 +1,2 @@
-{{ include "socialnetwork.templates.baseDeployment" . }}
+{{ include "socialnetwork.templates.baseNginxDeployment" . }}
  

--- a/socialNetwork/helm-chart/socialnetwork/charts/nginx-thrift/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/nginx-thrift/values.yaml
@@ -5,7 +5,7 @@ ports:
     targetPort: 8080
 
 container:
-  image: yg397/openresty-thrift:xenial
+  image: yg397/openresty-thrift
   imageVersion: xenial
   name: nginx-thrift
   ports: 

--- a/socialNetwork/helm-chart/socialnetwork/charts/nginx-thrift/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/nginx-thrift/values.yaml
@@ -13,7 +13,49 @@ container:
   env:
   - name: fqdn_suffix
     value: ".{{ .Release.Namespace }}.svc.cluster.local"
-  
+  volumeMounts:
+    - name: lua-scripts
+      mountPath: /usr/local/openresty/nginx/lua-scripts
+    - name: lua-thrift
+      mountPath: /usr/local/openresty/lualib/thrift
+    - name: pages
+      mountPath: /usr/local/openresty/nginx/pages
+    - name: gen-lua
+      mountPath: /gen-lua
+    - name: keys
+      mountPath: /keys
+
+
+initContainer:
+  image: alpine/git
+  imageVersion: latest
+  name: alpine-container
+  volumeMounts:
+  - name: lua-scripts
+    mountPath: /lua-scripts
+  - name: lua-thrift
+    mountPath: /lua-thrift
+  - name: pages
+    mountPath: /pages
+  - name: gen-lua
+    mountPath: /gen-lua
+  - name: keys
+    mountPath: /keys
+  command: "/bin/sh" 
+  args: ["-c", "git clone https://github.com/delimitrou/DeathStarBench.git /DeathStarBench &&
+            cp -r /DeathStarBench/socialNetwork/gen-lua/* /gen-lua/ &&
+            cp -r /DeathStarBench/socialNetwork/docker/openresty-thrift/lua-thrift/* /lua-thrift/ &&
+            cp -r /DeathStarBench/socialNetwork/nginx-web-server/lua-scripts/* /lua-scripts/ &&
+            cp -r /DeathStarBench/socialNetwork/nginx-web-server/pages/* /pages/ &&
+            cp /DeathStarBench/socialNetwork/keys/* /keys/ "]
+
+volumes:
+  - name: lua-scripts
+  - name: pages
+  - name: gen-lua
+  - name: lua-thrift
+  - name: keys
+
 configMaps:
   - name: jaeger-config.json
     mountPath: /usr/local/openresty/nginx/jaeger-config.json

--- a/socialNetwork/helm-chart/socialnetwork/templates/_baseNginxDeployment.tpl
+++ b/socialNetwork/helm-chart/socialnetwork/templates/_baseNginxDeployment.tpl
@@ -1,0 +1,118 @@
+{{- define "socialnetwork.templates.baseNginxDeployment" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    service: {{ .Values.name }}
+  name: {{ .Values.name }}
+spec: 
+  replicas: {{ .Values.replicas | default .Values.global.replicas }}
+  selector:
+    matchLabels:
+      service: {{ .Values.name }}
+  template:
+    metadata:
+      labels:
+        service: {{ .Values.name }}
+        app: {{ .Values.name }}
+    spec: 
+      containers:
+      {{- with .Values.container }}
+      - name: "{{ .name }}"
+        image: {{ .dockerRegistry | default $.Values.global.dockerRegistry }}/{{ .image }}:{{ .imageVersion | default $.Values.global.defaultImageVersion }}
+        imagePullPolicy: {{ .imagePullPolicy | default $.Values.global.imagePullPolicy }}
+        ports:
+        {{- range $cport := .ports }}
+        - containerPort: {{ $cport.containerPort -}}
+        {{ end }} 
+        {{- if .env }}
+        env:
+        {{- range $e := .env}}
+        - name: {{ $e.name }}
+          value: "{{ (tpl ($e.value | toString) $) }}"
+        {{ end -}}
+        {{ end -}}
+        {{- if .command}}
+        command: 
+        - {{ .command }}
+        {{- end -}}
+        {{- if .args}}
+        args:
+        {{- range $arg := .args}}
+        - {{ $arg }}
+        {{- end -}}
+        {{- end }}
+        {{- if .resources }}  
+        resources:
+          {{ tpl .resources . | nindent 6 | trim }}
+        {{- else if hasKey $.Values.global "resources" }}           
+        resources:
+          {{ tpl $.Values.global.resources $ | nindent 6 | trim }}
+        {{- end }}  
+        {{- if $.Values.configMaps }}        
+        volumeMounts: 
+        {{- range $configMap := $.Values.configMaps }}
+        - name: {{ $.Values.name }}-config
+          mountPath: {{ $configMap.mountPath }}
+          subPath: {{ $configMap.name }}        
+        {{- end }}
+        {{- range .volumeMounts }}
+        - name: {{ .name }}
+          mountPath: {{ .mountPath }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
+
+      initContainers:
+      {{- with .Values.initContainer }}
+      - name: "{{ .name }}"
+        image: {{ .dockerRegistry | default $.Values.global.dockerRegistry }}/{{ .image }}:{{ .imageVersion | default $.Values.global.defaultImageVersion }}
+        imagePullPolicy: {{ .imagePullPolicy | default $.Values.global.imagePullPolicy }}
+        {{- if .command}}
+        command: 
+        - {{ .command }}
+        {{- end -}}
+        {{- if .env }}
+        env:
+        {{- range $e := .env}}
+        - name: {{ $e.name }}
+          value: "{{ (tpl ($e.value | toString) $) }}"
+        {{ end -}}
+        {{ end -}}
+        {{- if .args}}
+        args:
+        {{- range $arg := .args}}
+        - {{ $arg }}
+        {{- end -}}
+        {{- end }}
+        {{- if .volumeMounts }}        
+        volumeMounts: 
+        {{- range .volumeMounts }}
+        - name: {{ .name }}
+          mountPath: {{ .mountPath }}
+        {{- end }}
+        {{- end }}
+      {{- end -}}
+
+      {{- if $.Values.configMaps }}
+      volumes:
+      - name: {{ $.Values.name }}-config
+        configMap:
+          name: {{ $.Values.name }}
+      {{- range $.Values.volumes }}
+      - name: {{ .name }}
+        emptyDir: {}
+      {{- end }}
+      {{- end }}
+      
+      {{- if hasKey .Values "topologySpreadConstraints" }}
+      topologySpreadConstraints:
+        {{ tpl .Values.topologySpreadConstraints . | nindent 6 | trim }}
+      {{- else if hasKey $.Values.global  "topologySpreadConstraints" }}
+      topologySpreadConstraints:
+        {{ tpl $.Values.global.topologySpreadConstraints . | nindent 6 | trim }}
+      {{- end }}
+      hostname: {{ $.Values.name }}
+      restartPolicy: {{ .Values.restartPolicy | default .Values.global.restartPolicy}}
+
+  {{- end}}


### PR DESCRIPTION
Add init containers inside media-frontend and nginx-thrift that pull and mount files from the public DSB repo.
Remove Dockerfiles that built images (media-frontend and nginx-thrift) with the files mounted inside of them that are now pulled by init container.