### PR TITLE
Add wrk2 scripts with determined parameters

### DIFF
--- a/socialNetwork/wrk2/scripts/social-network-determinism/compose-post.lua
+++ b/socialNetwork/wrk2/scripts/social-network-determinism/compose-post.lua
@@ -1,0 +1,83 @@
+require "socket"
+math.randomseed(socket.gettime()*1000)
+math.random(); math.random(); math.random()
+
+local charset = {'q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p', 'a', 's',
+  'd', 'f', 'g', 'h', 'j', 'k', 'l', 'z', 'x', 'c', 'v', 'b', 'n', 'm', 'Q',
+  'W', 'E', 'R', 'T', 'Y', 'U', 'I', 'O', 'P', 'A', 'S', 'D', 'F', 'G', 'H',
+  'J', 'K', 'L', 'Z', 'X', 'C', 'V', 'B', 'N', 'M', '1', '2', '3', '4', '5',
+  '6', '7', '8', '9', '0'}
+
+local decset = {'1', '2', '3', '4', '5', '6', '7', '8', '9', '0'}
+
+-- load env vars
+local max_user_index = tonumber(os.getenv("max_user_index")) or 962
+local text_len = tonumber(os.getenv("text_len")) or 256
+local num_user_mentions = tonumber(os.getenv("num_user_mentions")) or 5
+local num_urls = tonumber(os.getenv("num_urls")) or 5
+local num_media = tonumber(os.getenv("num_media")) or 4
+
+local function stringRandom(length)
+  if length > 0 then
+    return stringRandom(length - 1) .. charset[math.random(1, #charset)]
+  else
+    return ""
+  end
+end
+
+local function decRandom(length)
+  if length > 0 then
+    return decRandom(length - 1) .. decset[math.random(1, #decset)]
+  else
+    return ""
+  end
+end
+
+request = function()
+  local user_index = math.random(1, max_user_index)
+  local username = "username_" .. tostring(user_index)
+  local user_id = tostring(user_index)
+  local text = stringRandom(text_len)
+  local media_ids = '['
+  local media_types = '['
+
+  for i = 0, num_user_mentions, 1 do
+    local user_mention_id
+    while (true) do
+      user_mention_id = math.random(1, max_user_index)
+      if user_index ~= user_mention_id then
+        break
+      end
+    end
+    text = text .. " @username_" .. tostring(user_mention_id)
+  end
+
+  for i = 0, num_urls, 1 do
+    text = text .. " http://" .. stringRandom(64)
+  end
+
+  for i = 0, num_media, 1 do
+    local media_id = decRandom(18)
+    media_ids = media_ids .. "\"" .. media_id .. "\","
+    media_types = media_types .. "\"png\","
+  end
+
+  media_ids = media_ids:sub(1, #media_ids - 1) .. "]"
+  media_types = media_types:sub(1, #media_types - 1) .. "]"
+
+  local method = "POST"
+  local path = "http://localhost:8080/wrk2-api/post/compose"
+  local headers = {}
+  local body
+  headers["Content-Type"] = "application/x-www-form-urlencoded"
+  if num_media then
+    body   = "username=" .. username .. "&user_id=" .. user_id ..
+        "&text=" .. text .. "&media_ids=" .. media_ids ..
+        "&media_types=" .. media_types .. "&post_type=0"
+  else
+    body   = "username=" .. username .. "&user_id=" .. user_id ..
+        "&text=" .. text .. "&media_ids=" .. "&post_type=0"
+  end
+
+  return wrk.format(method, path, headers, body)
+end

--- a/socialNetwork/wrk2/scripts/social-network-determinism/mixed-workload.lua
+++ b/socialNetwork/wrk2/scripts/social-network-determinism/mixed-workload.lua
@@ -1,0 +1,132 @@
+require "socket"
+local time = socket.gettime()*1000
+math.randomseed(time)
+math.random(); math.random(); math.random()
+
+local charset = {'q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p', 'a', 's',
+  'd', 'f', 'g', 'h', 'j', 'k', 'l', 'z', 'x', 'c', 'v', 'b', 'n', 'm', 'Q',
+  'W', 'E', 'R', 'T', 'Y', 'U', 'I', 'O', 'P', 'A', 'S', 'D', 'F', 'G', 'H',
+  'J', 'K', 'L', 'Z', 'X', 'C', 'V', 'B', 'N', 'M', '1', '2', '3', '4', '5',
+  '6', '7', '8', '9', '0'}
+
+local decset = {'1', '2', '3', '4', '5', '6', '7', '8', '9', '0'}
+
+-- load env vars
+local max_user_index = tonumber(os.getenv("max_user_index")) or 962
+local text_len = tonumber(os.getenv("text_len")) or 256
+local num_user_mentions = tonumber(os.getenv("num_user_mentions")) or 5
+local num_urls = tonumber(os.getenv("num_urls")) or 5
+local num_media = tonumber(os.getenv("num_media")) or 4
+
+local home_start = tostring(tonumber(os.getenv("home_start")) or 0)
+local home_stop = tostring(tonumber(os.getenv("home_stop")) or 10)
+
+local user_start = tostring(tonumber(os.getenv("user_start")) or 0)
+local user_stop = tostring(tonumber(os.getenv("user_stop")) or 10)
+
+local function stringRandom(length)
+  if length > 0 then
+    return stringRandom(length - 1) .. charset[math.random(1, #charset)]
+  else
+    return ""
+  end
+end
+
+local function decRandom(length)
+  if length > 0 then
+    return decRandom(length - 1) .. decset[math.random(1, #decset)]
+  else
+    return ""
+  end
+end
+
+local function compose_post()
+  local user_index = math.random(1, max_user_index)
+  local username = "username_" .. tostring(user_index)
+  local user_id = tostring(user_index)
+  local text = stringRandom(text_len)
+  local media_ids = '['
+  local media_types = '['
+
+  for i = 0, num_user_mentions, 1 do
+    local user_mention_id
+    while (true) do
+      user_mention_id = math.random(1, max_user_index)
+      if user_index ~= user_mention_id then
+        break
+      end
+    end
+    text = text .. " @username_" .. tostring(user_mention_id)
+  end
+
+  for i = 0, num_urls, 1 do
+    text = text .. " http://" .. stringRandom(64)
+  end
+
+  for i = 0, num_media, 1 do
+    local media_id = decRandom(18)
+    media_ids = media_ids .. "\"" .. media_id .. "\","
+    media_types = media_types .. "\"png\","
+  end
+
+  media_ids = media_ids:sub(1, #media_ids - 1) .. "]"
+  media_types = media_types:sub(1, #media_types - 1) .. "]"
+
+  local method = "POST"
+  local path = "http://localhost:8080/wrk2-api/post/compose"
+  local headers = {}
+  local body
+  headers["Content-Type"] = "application/x-www-form-urlencoded"
+  if num_media then
+    body   = "username=" .. username .. "&user_id=" .. user_id ..
+        "&text=" .. text .. "&media_ids=" .. media_ids ..
+        "&media_types=" .. media_types .. "&post_type=0"
+  else
+    body   = "username=" .. username .. "&user_id=" .. user_id ..
+        "&text=" .. text .. "&media_ids=" .. "&post_type=0"
+  end
+
+  return wrk.format(method, path, headers, body)
+end
+
+local function read_user_timeline()
+  local user_id = tostring(math.random(1, max_user_index))
+  local start = user_start
+  local stop = user_stop
+
+  local args = "user_id=" .. user_id .. "&start=" .. start .. "&stop=" .. stop
+  local method = "GET"
+  local headers = {}
+  headers["Content-Type"] = "application/x-www-form-urlencoded"
+  local path = "http://localhost:8080/wrk2-api/user-timeline/read?" .. args
+  return wrk.format(method, path, headers, nil)
+end
+
+local function read_home_timeline()
+    local user_id = tostring(math.random(1, max_user_index))
+    local start = home_start
+    local stop = home_stop
+
+    local args = "user_id=" .. user_id .. "&start=" .. start .. "&stop=" .. stop
+    local method = "GET"
+    local headers = {}
+    headers["Content-Type"] = "application/x-www-form-urlencoded"
+    local path = "http://localhost:8080/wrk2-api/home-timeline/read?" .. args
+    return wrk.format(method, path, headers, nil)
+  end
+
+request = function()
+    cur_time = math.floor(socket.gettime())
+    local read_home_timeline_ratio = 0.60
+    local read_user_timeline_ratio = 0.30
+    local compose_post_ratio       = 0.10
+
+    local coin = math.random()
+    if coin < read_home_timeline_ratio then
+      return read_home_timeline()
+    elseif coin < read_home_timeline_ratio + read_user_timeline_ratio then
+      return read_user_timeline()
+    else
+      return compose_post()
+    end
+  end

--- a/socialNetwork/wrk2/scripts/social-network-determinism/read-home-timeline.lua
+++ b/socialNetwork/wrk2/scripts/social-network-determinism/read-home-timeline.lua
@@ -1,0 +1,21 @@
+require "socket"
+local time = socket.gettime()*1000
+math.randomseed(time)
+math.random(); math.random(); math.random()
+
+-- load env vars
+local max_user_index = tonumber(os.getenv("max_user_index")) or 962
+local start = tostring(tonumber(os.getenv("start")) or 0)
+local stop = tostring(tonumber(os.getenv("stop")) or 10)
+
+request = function()
+  local user_id = tostring(math.random(1, max_user_index))
+
+  local args = "user_id=" .. user_id .. "&start=" .. start .. "&stop=" .. stop
+  local method = "GET"
+  local headers = {}
+  headers["Content-Type"] = "application/x-www-form-urlencoded"
+  local path = "http://localhost:8080/wrk2-api/home-timeline/read?" .. args
+  return wrk.format(method, path, headers, nil)
+
+end

--- a/socialNetwork/wrk2/scripts/social-network-determinism/read-user-timeline.lua
+++ b/socialNetwork/wrk2/scripts/social-network-determinism/read-user-timeline.lua
@@ -1,0 +1,21 @@
+require "socket"
+local time = socket.gettime()*1000
+math.randomseed(time)
+math.random(); math.random(); math.random()
+
+-- load env vars
+local max_user_index = tonumber(os.getenv("max_user_index")) or 962
+local start = tostring(tonumber(os.getenv("start")) or 0)
+local stop = tostring(tonumber(os.getenv("stop")) or 10)
+
+request = function()
+  local user_id = tostring(math.random(1, max_user_index))
+
+  local args = "user_id=" .. user_id .. "&start=" .. start .. "&stop=" .. stop
+  local method = "GET"
+  local headers = {}
+  headers["Content-Type"] = "application/x-www-form-urlencoded"
+  local path = "http://localhost:8080/wrk2-api/user-timeline/read?" .. args
+  return wrk.format(method, path, headers, nil)
+
+end


### PR DESCRIPTION
Users can use these wrk2 scripts and pass pre-determined parameters for performance testing. For mixed workload, the configurable parameters that can be passed to the workload generators as env variables are:

`text_len`: length of text for compose-post
`num_user_mentions`: the number of users that are mentioned in the compose-post
`num_urls`: number of URLs in the compose-post
`num_media`: number of media in the compose-post
`home_start`: start post id of read-home-timeline
`home_stop`: end post id of read-home-timeline
`user_start`: start post id of read-user-timeline
`user_stop`: end post id of read-user-timeline