### PR TITLE
SocialNetwork: add pipeline for redis cluster

### DIFF
--- a/socialNetwork/docker/thrift-microservice-deps/cpp/Dockerfile
+++ b/socialNetwork/docker/thrift-microservice-deps/cpp/Dockerfile
@@ -123,6 +123,8 @@ RUN apt-get update \
   && git clone https://github.com/sewenew/redis-plus-plus.git \
   && cd redis-plus-plus \
   && git checkout ${LIB_REDIS_PLUS_PLUS_VERSION} \
+  && sed -i '/Transaction transaction/i\\    ShardsPool* get_shards_pool(){\n        return &_pool;\n    }\n' \
+     src/sw/redis++/redis_cluster.h \
   && cmake -DREDIS_PLUS_PLUS_USE_TLS=ON . \
   && make -j$(nproc) \
   && make install \


### PR DESCRIPTION
Create pipelines to improve the performance. Get 10% throughput improvement on my K8s cluster with mixed-workload.

With this change, multi-pipeline will automatically created, and match each request to corresponding pipelines.
At most 5 pipleines will create(align with redis nodes count)

Since nearly no helping for SocialGraphHandler::Follow, not enabled pipeline for it.