### PR TITLE
SocialNetwork: Fix "Non-2xx or 3xx response" failures

### DIFF
--- a/socialNetwork/src/ComposePostService/ComposePostHandler.h
+++ b/socialNetwork/src/ComposePostService/ComposePostHandler.h
@@ -412,14 +412,18 @@ void ComposePostHandler::ComposePost(
     user_mention_ids.emplace_back(item.user_id);
   }
 
+  //In mixed workloed condition, need to make sure _UploadPostHelper execute
+  //Before _UploadUserTimelineHelper and _UploadHomeTimelineHelper.
+  //Change _UploadUserTimelineHelper and _UploadHomeTimelineHelper to deferred.
+  //To let them start execute after post_future.get() return.
   auto post_future =
       std::async(std::launch::async, &ComposePostHandler::_UploadPostHelper,
                  this, req_id, post, writer_text_map);
   auto user_timeline_future = std::async(
-      std::launch::async, &ComposePostHandler::_UploadUserTimelineHelper, this,
+      std::launch::deferred, &ComposePostHandler::_UploadUserTimelineHelper, this,
       req_id, post.post_id, user_id, timestamp, writer_text_map);
   auto home_timeline_future = std::async(
-      std::launch::async, &ComposePostHandler::_UploadHomeTimelineHelper, this,
+      std::launch::deferred, &ComposePostHandler::_UploadHomeTimelineHelper, this,
       req_id, post.post_id, user_id, timestamp, user_mention_ids,
       writer_text_map);
 

--- a/socialNetwork/src/PostStorageSerivce/PostStorageHandler.h
+++ b/socialNetwork/src/PostStorageSerivce/PostStorageHandler.h
@@ -370,6 +370,7 @@ void PostStorageHandler::ReadPosts(
 
   std::set<int64_t> post_ids_not_cached(post_ids.begin(), post_ids.end());
   if (post_ids_not_cached.size() != post_ids.size()) {
+    LOG(error)<< "Post_ids are duplicated";
     ServiceException se;
     se.errorCode = ErrorCode::SE_THRIFT_HANDLER_ERROR;
     se.message = "Post_ids are duplicated";

--- a/socialNetwork/src/UserTimelineService/UserTimelineHandler.h
+++ b/socialNetwork/src/UserTimelineService/UserTimelineHandler.h
@@ -245,7 +245,11 @@ void UserTimelineHandler::ReadUserTimeline(
         auto curr_post_id = bson_iter_int64(&post_id_child);
         auto curr_timestamp = bson_iter_int64(&timestamp_child);
         if (idx >= mongo_start) {
-          post_ids.emplace_back(curr_post_id);
+          //In mixed workload condition, post may composed between redis and mongo read
+          //mongodb index will shift and duplicate post_id occurs
+          if ( std::find(post_ids.begin(), post_ids.end(), curr_post_id) == post_ids.end() ) {
+            post_ids.emplace_back(curr_post_id);
+          }
         }
         redis_update_map.insert(std::make_pair(std::to_string(curr_post_id),
                                                (double)curr_timestamp));


### PR DESCRIPTION
Fixed Non-2xx or 3xx response. include failures below(error message from Nginx and service logs):
 1. Get home-timeline failure: Return set incomplete
 2. Get user-timeline failure: Post_ids are duplicated