### PR TITLE
[HotelReservation] Set zerolog global log level

### DIFF
--- a/hotelReservation/cmd/frontend/main.go
+++ b/hotelReservation/cmd/frontend/main.go
@@ -11,11 +11,13 @@ import (
 	"github.com/harlow/go-micro-services/registry"
 	"github.com/harlow/go-micro-services/services/frontend"
 	"github.com/harlow/go-micro-services/tracing"
+	"github.com/harlow/go-micro-services/tune"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
 func main() {
+	tune.Init()
 	log.Logger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}).With().Timestamp().Caller().Logger()
 
 	log.Info().Msg("Reading config...")

--- a/hotelReservation/cmd/geo/main.go
+++ b/hotelReservation/cmd/geo/main.go
@@ -11,11 +11,13 @@ import (
 	"github.com/harlow/go-micro-services/registry"
 	"github.com/harlow/go-micro-services/services/geo"
 	"github.com/harlow/go-micro-services/tracing"
+	"github.com/harlow/go-micro-services/tune"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
 func main() {
+	tune.Init()
 	log.Logger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}).With().Timestamp().Caller().Logger()
 
 	log.Info().Msg("Reading config...")

--- a/hotelReservation/cmd/profile/main.go
+++ b/hotelReservation/cmd/profile/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/harlow/go-micro-services/registry"
 	"github.com/harlow/go-micro-services/services/profile"
 	"github.com/harlow/go-micro-services/tracing"
+	"github.com/harlow/go-micro-services/tune"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
@@ -19,6 +20,7 @@ import (
 )
 
 func main() {
+	tune.Init()
 	log.Logger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}).With().Timestamp().Caller().Logger()
 
 	log.Info().Msg("Reading config...")

--- a/hotelReservation/cmd/rate/main.go
+++ b/hotelReservation/cmd/rate/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/harlow/go-micro-services/registry"
 	"github.com/harlow/go-micro-services/services/rate"
 	"github.com/harlow/go-micro-services/tracing"
+	"github.com/harlow/go-micro-services/tune"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
@@ -19,6 +20,7 @@ import (
 )
 
 func main() {
+	tune.Init()
 	log.Logger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}).With().Timestamp().Caller().Logger()
 
 	log.Info().Msg("Reading config...")

--- a/hotelReservation/cmd/recommendation/main.go
+++ b/hotelReservation/cmd/recommendation/main.go
@@ -12,12 +12,14 @@ import (
 	"github.com/harlow/go-micro-services/registry"
 	"github.com/harlow/go-micro-services/services/recommendation"
 	"github.com/harlow/go-micro-services/tracing"
+	"github.com/harlow/go-micro-services/tune"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	// "github.com/bradfitz/gomemcache/memcache"
 )
 
 func main() {
+	tune.Init()
 	log.Logger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}).With().Timestamp().Caller().Logger()
 
 	log.Info().Msg("Reading config...")

--- a/hotelReservation/cmd/reservation/main.go
+++ b/hotelReservation/cmd/reservation/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/harlow/go-micro-services/registry"
 	"github.com/harlow/go-micro-services/services/reservation"
 	"github.com/harlow/go-micro-services/tracing"
+	"github.com/harlow/go-micro-services/tune"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
@@ -20,6 +21,7 @@ import (
 )
 
 func main() {
+	tune.Init()
 	log.Logger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}).With().Timestamp().Caller().Logger()
 
 	log.Info().Msg("Reading config...")

--- a/hotelReservation/cmd/search/main.go
+++ b/hotelReservation/cmd/search/main.go
@@ -12,11 +12,13 @@ import (
 	"github.com/harlow/go-micro-services/registry"
 	"github.com/harlow/go-micro-services/services/search"
 	"github.com/harlow/go-micro-services/tracing"
+	"github.com/harlow/go-micro-services/tune"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
 func main() {
+	tune.Init()
 	log.Logger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}).With().Timestamp().Caller().Logger()
 
 	log.Info().Msg("Reading config...")

--- a/hotelReservation/cmd/user/main.go
+++ b/hotelReservation/cmd/user/main.go
@@ -11,11 +11,13 @@ import (
 	"github.com/harlow/go-micro-services/registry"
 	"github.com/harlow/go-micro-services/services/user"
 	"github.com/harlow/go-micro-services/tracing"
+	"github.com/harlow/go-micro-services/tune"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
 func main() {
+	tune.Init()
 	// initializeDatabase()
 	log.Logger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}).With().Timestamp().Caller().Logger()
 

--- a/hotelReservation/docker-compose.yml
+++ b/hotelReservation/docker-compose.yml
@@ -12,6 +12,7 @@ services:
   frontend:
     environment:
       - TLS
+      - LOG_LEVEL
     build: .
     image: hotel_reserv_frontend_single_node
     entrypoint: frontend
@@ -25,6 +26,7 @@ services:
   profile:
     environment:
       - TLS
+      - LOG_LEVEL
     build: .
     image: hotel_reserv_profile_single_node
     entrypoint: profile
@@ -45,12 +47,14 @@ services:
     restart: always
     environment:
       - TLS
+      - LOG_LEVEL
       # - GRPC_GO_LOG_VERBOSITY_LEVEL=2
       # - GRPC_GO_LOG_SEVERITY_LEVEL=info
 
   geo:
     environment:
       - TLS
+      - LOG_LEVEL
     build: .
     image: hotel_reserv_geo_single_node
     entrypoint: geo
@@ -63,6 +67,7 @@ services:
   rate:
     environment:
       - TLS
+      - LOG_LEVEL
     build: .
     image: hotel_reserv_rate_single_node
     entrypoint: rate
@@ -76,6 +81,7 @@ services:
   recommendation:
     environment:
       - TLS
+      - LOG_LEVEL
     build: .
     image: hotel_reserv_recommend_single_node
     entrypoint: recommendation
@@ -88,6 +94,7 @@ services:
   user:
     environment:
       - TLS
+      - LOG_LEVEL
     build: .
     image: hotel_reserv_user_single_node
     entrypoint: user
@@ -100,6 +107,7 @@ services:
   reservation:
     environment:
       - TLS
+      - LOG_LEVEL
     build: .
     image: hotel_reserv_rsv_single_node
     entrypoint: reservation

--- a/hotelReservation/tune/setting.go
+++ b/hotelReservation/tune/setting.go
@@ -1,0 +1,39 @@
+package tune
+
+import (
+	"os"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+var (
+	defaultLogLevel string = "info"
+)
+
+func setLogLevel()  {
+	logLevel := defaultLogLevel
+	if val, ok := os.LookupEnv("LOG_LEVEL"); ok {
+		logLevel = val
+	}
+        switch logLevel {
+        case "", "ERROR", "error": // If env is unset, set level to ERROR.
+		zerolog.SetGlobalLevel(zerolog.ErrorLevel)
+        case "WARNING", "warning":
+		zerolog.SetGlobalLevel(zerolog.WarnLevel)
+        case "DEBUG", "debug":
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+        case "INFO", "info":
+		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+        case "TRACE", "trace":
+		zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	default: // Set default log level to info
+		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+        }
+
+	log.Info().Msgf("Set global log level: %s", logLevel)
+}
+
+func Init() {
+	setLogLevel()
+}


### PR DESCRIPTION
In order to decrease the log to affect the performance of HotelReservation.
Add a mechanism to set zerolog global log level.

This commit will do the following things:
1. Set log level at the beginning of every service.
6. Add a new environment variable named "LOG_LEVEL" for every service.
7. By default, the log level is "INFO".