### PR TITLE
Fix Python 3.10 "DeprecationWarning: There is no current event loop"

### DIFF
--- a/socialNetwork/scripts/init_social_graph.py
+++ b/socialNetwork/scripts/init_social_graph.py
@@ -150,11 +150,11 @@ if __name__ == '__main__':
 
   addr = 'http://{}:{}'.format(args.ip, args.port)
   limit = args.limit
-  loop = asyncio.get_event_loop()
-  future = asyncio.ensure_future(register(addr, nodes, limit))
+  loop = asyncio.new_event_loop()
+  future = asyncio.ensure_future(register(addr, nodes, limit), loop=loop)
   loop.run_until_complete(future)
-  future = asyncio.ensure_future(follow(addr, edges, limit))
+  future = asyncio.ensure_future(follow(addr, edges, limit), loop=loop)
   loop.run_until_complete(future)
   if args.compose:
-    future = asyncio.ensure_future(compose(addr, nodes, limit))
+    future = asyncio.ensure_future(compose(addr, nodes, limit), loop=loop)
     loop.run_until_complete(future)


### PR DESCRIPTION
When running python3 scripts/init_social_graph.py on Python 3.10 or above (i.e. on Ubuntu 22.04), warnings like the following are displayed:

```
socialNetwork/scripts/init_social_graph.py.orig:153: DeprecationWarning: There is no current event loop
  loop = asyncio.get_event_loop()
socialNetwork/scripts/init_social_graph.py.orig:154: DeprecationWarning: There is no current event loop
  future = asyncio.ensure_future(register(addr, nodes, limit))
socialNetwork/scripts/init_social_graph.py.orig:156: DeprecationWarning: There is no current event loop
  future = asyncio.ensure_future(follow(addr, edges, limit))
```

These changes eliminate those warnings by using asyncio.new_event_loop() and specifying the loop when calling asyncio.ensure_future().

Ref:
https://docs.python.org/3.10/library/asyncio-eventloop.html#asyncio.get_event_loop
https://docs.python.org/3/library/asyncio-future.html#asyncio.ensure_future
