### PR TITLE
Fix "attempt to index global 'socket' (a nil value)" errors

### DIFF
--- a/hotelReservation/wrk2/scripts/hotel-reservation/mixed-workload_type_1.lua
+++ b/hotelReservation/wrk2/scripts/hotel-reservation/mixed-workload_type_1.lua
@@ -1,4 +1,4 @@
-require "socket"
+local socket = require("socket")
 math.randomseed(socket.gettime()*1000)
 math.random(); math.random(); math.random()
 

--- a/mediaMicroservices/wrk2/scripts/media-microservices/compose-review.lua
+++ b/mediaMicroservices/wrk2/scripts/media-microservices/compose-review.lua
@@ -1,4 +1,4 @@
-require "socket"
+local socket = require("socket")
 time = socket.gettime()*1000
 math.randomseed(time)
 math.random(); math.random(); math.random()

--- a/socialNetwork/wrk2/scripts/social-network-determinism/compose-post.lua
+++ b/socialNetwork/wrk2/scripts/social-network-determinism/compose-post.lua
@@ -1,4 +1,4 @@
-require "socket"
+local socket = require("socket")
 math.randomseed(socket.gettime()*1000)
 math.random(); math.random(); math.random()
 

--- a/socialNetwork/wrk2/scripts/social-network-determinism/mixed-workload.lua
+++ b/socialNetwork/wrk2/scripts/social-network-determinism/mixed-workload.lua
@@ -1,4 +1,4 @@
-require "socket"
+local socket = require("socket")
 local time = socket.gettime()*1000
 math.randomseed(time)
 math.random(); math.random(); math.random()

--- a/socialNetwork/wrk2/scripts/social-network-determinism/read-home-timeline.lua
+++ b/socialNetwork/wrk2/scripts/social-network-determinism/read-home-timeline.lua
@@ -1,4 +1,4 @@
-require "socket"
+local socket = require("socket")
 local time = socket.gettime()*1000
 math.randomseed(time)
 math.random(); math.random(); math.random()

--- a/socialNetwork/wrk2/scripts/social-network-determinism/read-user-timeline.lua
+++ b/socialNetwork/wrk2/scripts/social-network-determinism/read-user-timeline.lua
@@ -1,4 +1,4 @@
-require "socket"
+local socket = require("socket")
 local time = socket.gettime()*1000
 math.randomseed(time)
 math.random(); math.random(); math.random()

--- a/socialNetwork/wrk2/scripts/social-network/compose-post.lua
+++ b/socialNetwork/wrk2/scripts/social-network/compose-post.lua
@@ -1,4 +1,4 @@
-require "socket"
+local socket = require("socket")
 math.randomseed(socket.gettime()*1000)
 math.random(); math.random(); math.random()
 

--- a/socialNetwork/wrk2/scripts/social-network/mixed-workload.lua
+++ b/socialNetwork/wrk2/scripts/social-network/mixed-workload.lua
@@ -1,4 +1,4 @@
-require "socket"
+local socket = require("socket")
 local time = socket.gettime()*1000
 math.randomseed(time)
 math.random(); math.random(); math.random()

--- a/socialNetwork/wrk2/scripts/social-network/read-home-timeline.lua
+++ b/socialNetwork/wrk2/scripts/social-network/read-home-timeline.lua
@@ -1,4 +1,4 @@
-require "socket"
+local socket = require("socket")
 local time = socket.gettime()*1000
 math.randomseed(time)
 math.random(); math.random(); math.random()

--- a/socialNetwork/wrk2/scripts/social-network/read-user-timeline.lua
+++ b/socialNetwork/wrk2/scripts/social-network/read-user-timeline.lua
@@ -1,4 +1,4 @@
-require "socket"
+local socket = require("socket")
 local time = socket.gettime()*1000
 math.randomseed(time)
 math.random(); math.random(); math.random()


### PR DESCRIPTION
This resolves errors like the following:
```
# ./wrk -D exp -t 1 -c 1 -d 10 -R 1 -s ./scripts/social-network/mixed-workload.lua http://127.0.0.1:8080/wrk2-api
./scripts/social-network/mixed-workload.lua: ./scripts/social-network/mixed-workload.lua:2: attempt to index global 'socket' (a nil value)
./scripts/social-network/mixed-workload.lua: ./scripts/social-network/mixed-workload.lua:2: attempt to index global 'socket' (a nil value)
Running 10s test @ http://127.0.0.1:8080/wrk2-api
```
All Lua scripts have been updated to use the syntax from the [LuaSocket Introduction](https://lunarmodules.github.io/luasocket/introduction.html), namely `local socket = require("socket")`, which eliminates the error.

Resolves #192 
