### PR TITLE
[SocialNetwork] Add CI pipeline

### DIFF
--- a/.github/workflows/socialnetwork-push.yaml
+++ b/.github/workflows/socialnetwork-push.yaml
@@ -1,0 +1,57 @@
+name: Push SocialNetwork
+
+on:
+  push: 
+    branches: [ master ]
+    paths: 
+      - 'socialNetwork/**'
+
+env:
+  IMAGE_BASE_NAME: 'deathstarbench/social-network-microservices'
+  REPO_PATH: 'socialNetwork'
+  TAG_PREFIX: 'socialNetwork'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: master
+        fetch-depth: 0 
+    - name: Login to ACR
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_REGISTRY_LOGIN }}
+        password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+    - name: Build docker image
+      run: docker build -f "${{ env.REPO_PATH }}/Dockerfile" -t ${{ env.IMAGE_BASE_NAME }} ${{ env.REPO_PATH }}
+    - name: Calculate new version
+      id: new-version
+      uses: codacy/git-version@2.4.0
+      with:
+        prefix: "${{ env.TAG_PREFIX }}-"
+        log-paths: "${{ env.REPO_PATH }}/"
+      if: github.ref == 'refs/heads/master'
+    - name: Create tag
+      uses: actions/github-script@v5
+      with:
+        script: |
+          github.rest.git.createRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: 'refs/tags/${{ steps.new-version.outputs.VERSION }}',
+            sha: context.sha
+          })
+    - name: Retrieve version number
+      run: TEMP=${{ steps.new-version.outputs.VERSION }} && echo VERSION_NUMBER=${TEMP#*-} >> $GITHUB_ENV
+    - name: Create image full name
+      run: echo "IMAGE_ID=${{ env.IMAGE_BASE_NAME }}:${{ env.VERSION_NUMBER }}" >> $GITHUB_ENV
+    - name: Tag image
+      run: docker tag ${{ env.IMAGE_BASE_NAME }} ${{ env.IMAGE_ID }}
+    - name: Push docker image
+      run: docker push ${{ env.IMAGE_ID }}
+    - name: Tag image as latest
+      run: docker tag ${{ env.IMAGE_BASE_NAME }} ${{ env.IMAGE_BASE_NAME }}:latest
+    - name: Push latest
+      run: docker push ${{ env.IMAGE_BASE_NAME }}:latest


### PR DESCRIPTION
Here is a CI pipeline which is triggered after every change made to socialNetwork and: 
* rebuilds social-network-microservices image,
* calculates the new version,
* tags the image with the new version and pushes to docker hub,
* tags the repository with the new version using "socialNetwork" prefix.

It is required to add two secrets with read/write permissions: DOCKER_REGISTRY_LOGIN and DOCKER_REGISTRY_PASSWORD.