### PR TITLE
(feat) Update social-network image references to target new registry

### DIFF
--- a/socialNetwork/docker-compose-sharding.yml
+++ b/socialNetwork/docker-compose-sharding.yml
@@ -4,7 +4,7 @@
 version: "3.9"
 services:
   social-graph-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: social-graph-service
     #    ports:
     #      - 10000:9090
@@ -68,7 +68,7 @@ services:
     entrypoint: /bin/bash /scripts/setup_redis_cluster.sh -n home-timeline-redis
 
   compose-post-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: compose-post-service
     #    ports:
     #      - 10001:9090
@@ -81,7 +81,7 @@ services:
       - ./config:/social-network-microservices/config
 
   post-storage-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: post-storage-service
     # ports:
     #   - 10002:9090
@@ -110,7 +110,7 @@ services:
     restart: always
 
   user-timeline-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: user-timeline-service
     #    ports:
     #      - 10003:9090
@@ -154,7 +154,7 @@ services:
     restart: always
 
   url-shorten-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: url-shorten-service
     #    ports:
     #      - 10004:9090
@@ -183,7 +183,7 @@ services:
     restart: always
 
   user-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: user-service
     #    ports:
     #      - 10005:9090
@@ -212,7 +212,7 @@ services:
     restart: always
 
   media-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: media-service
     #    ports:
     #      - 10006:9090
@@ -241,7 +241,7 @@ services:
     restart: always
 
   text-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: text-service
     #    ports:
     #      - 10007:9090
@@ -254,7 +254,7 @@ services:
       - ./config:/social-network-microservices/config
 
   unique-id-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: unique-id-service
     #    ports:
     #      - 10008:9090
@@ -267,7 +267,7 @@ services:
       - ./config:/social-network-microservices/config
 
   user-mention-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: user-mention-service
     #    ports:
     #      - 10009:9090
@@ -280,7 +280,7 @@ services:
       - ./config:/social-network-microservices/config
 
   home-timeline-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: home-timeline-service
     #    ports:
     #      - 10010:9090

--- a/socialNetwork/docker-compose-swarm.yml
+++ b/socialNetwork/docker-compose-swarm.yml
@@ -38,7 +38,7 @@ services:
           memory: 1G
     command: ["ComposePostService"]
     hostname: compose-post-service
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     volumes:
       - ./config:/social-network-microservices/config
       - ./keys:/keys
@@ -68,7 +68,7 @@ services:
           memory: 1G
     command: ["HomeTimelineService"]
     hostname: home-timeline-service
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     volumes:
       - ./config:/social-network-microservices/config
       - ./keys:/keys
@@ -132,7 +132,7 @@ services:
           memory: 1G
     command: ["MediaService"]
     hostname: media-service
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     volumes:
       - ./config:/social-network-microservices/config
       - ./keys:/keys
@@ -201,7 +201,7 @@ services:
           memory: 1G
     command: ["PostStorageService"]
     hostname: post-storage-service
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     volumes:
       - ./config:/social-network-microservices/config
       - ./keys:/keys
@@ -244,7 +244,7 @@ services:
           memory: 1G
     command: ["SocialGraphService"]
     hostname: social-graph-service
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     volumes:
       - ./config:/social-network-microservices/config
       - ./keys:/keys
@@ -263,7 +263,7 @@ services:
           memory: 1G
     command: ["TextService"]
     hostname: text-service
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     volumes:
       - ./config:/social-network-microservices/config
       - ./keys:/keys
@@ -282,7 +282,7 @@ services:
           memory: 1G
     command: ["UniqueIdService"]
     hostname: unique-id-service
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     volumes:
       - ./config:/social-network-microservices/config
       - ./keys:/keys
@@ -326,7 +326,7 @@ services:
           memory: 1G
     command: ["UrlShortenService"]
     hostname: url-shorten-service
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     volumes:
       - ./config:/social-network-microservices/config
       - ./keys:/keys
@@ -357,7 +357,7 @@ services:
           memory: 1G
     command: ["UserMentionService"]
     hostname: user-mention-service
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     volumes:
       - ./config:/social-network-microservices/config
       - ./keys:/keys
@@ -389,7 +389,7 @@ services:
           memory: 1G
     command: ["UserService"]
     hostname: user-service
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     volumes:
       - ./config:/social-network-microservices/config
       - ./keys:/keys
@@ -431,7 +431,7 @@ services:
           memory: 1G
     command: ["UserTimelineService"]
     hostname: user-timeline-service
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     volumes:
       - ./config:/social-network-microservices/config
 

--- a/socialNetwork/docker-compose-tls.yml
+++ b/socialNetwork/docker-compose-tls.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   config:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: config
     environment:
       - TLS
@@ -11,7 +11,7 @@ services:
       - ./nginx-web-server/conf/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
 
   social-graph-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: social-graph-service
     #    ports:
     #      - 10000:9090
@@ -71,7 +71,7 @@ services:
       - ./keys:/keys
 
   compose-post-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: compose-post-service
     #    ports:
     #      - 10001:9090
@@ -87,7 +87,7 @@ services:
       - ./keys:/keys
 
   post-storage-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: post-storage-service
     ports:
       - 10002:9090
@@ -129,7 +129,7 @@ services:
       - ./keys:/keys
 
   user-timeline-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: user-timeline-service
     #    ports:
     #      - 10003:9090
@@ -175,7 +175,7 @@ services:
       - ./keys:/keys
 
   url-shorten-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: url-shorten-service
     #    ports:
     #      - 10004:9090
@@ -217,7 +217,7 @@ services:
       - ./keys:/keys
 
   user-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: user-service
     #    ports:
     #      - 10005:9090
@@ -259,7 +259,7 @@ services:
       - ./keys:/keys
 
   media-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: media-service
     #    ports:
     #      - 10006:9090
@@ -301,7 +301,7 @@ services:
       - ./keys:/keys
 
   text-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: text-service
     #    ports:
     #      - 10007:9090
@@ -317,7 +317,7 @@ services:
       - ./keys:/keys
 
   unique-id-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: unique-id-service
     #    ports:
     #      - 10008:9090
@@ -333,7 +333,7 @@ services:
       - ./keys:/keys
 
   user-mention-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: user-mention-service
     #    ports:
     #      - 10009:9090
@@ -349,7 +349,7 @@ services:
       - ./keys:/keys
 
   home-timeline-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: home-timeline-service
     #    ports:
     #      - 10010:9090

--- a/socialNetwork/docker-compose.yml
+++ b/socialNetwork/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   social-graph-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: social-graph-service
     #    ports:
     #      - 10000:9090
@@ -37,7 +37,7 @@ services:
     restart: always
 
   compose-post-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: compose-post-service
     #    ports:
     #      - 10001:9090
@@ -50,7 +50,7 @@ services:
       - ./config:/social-network-microservices/config
 
   post-storage-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: post-storage-service
     ports:
       - 10002:9090
@@ -79,7 +79,7 @@ services:
     restart: always
 
   user-timeline-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: user-timeline-service
     #    ports:
     #      - 10003:9090
@@ -108,7 +108,7 @@ services:
     restart: always
 
   url-shorten-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: url-shorten-service
     #    ports:
     #      - 10004:9090
@@ -137,7 +137,7 @@ services:
     restart: always
 
   user-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: user-service
     #    ports:
     #      - 10005:9090
@@ -166,7 +166,7 @@ services:
     restart: always
 
   media-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: media-service
     #    ports:
     #      - 10006:9090
@@ -195,7 +195,7 @@ services:
     restart: always
 
   text-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: text-service
     #    ports:
     #      - 10007:9090
@@ -208,7 +208,7 @@ services:
       - ./config:/social-network-microservices/config
 
   unique-id-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: unique-id-service
     #    ports:
     #      - 10008:9090
@@ -221,7 +221,7 @@ services:
       - ./config:/social-network-microservices/config
 
   user-mention-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: user-mention-service
     #    ports:
     #      - 10009:9090
@@ -234,7 +234,7 @@ services:
       - ./config:/social-network-microservices/config
 
   home-timeline-service:
-    image: yg397/social-network-microservices:latest
+    image: deathstarbench/social-network-microservices:latest
     hostname: home-timeline-service
     #    ports:
     #      - 10010:9090

--- a/socialNetwork/helm-chart/socialnetwork/charts/compose-post-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/compose-post-service/values.yaml
@@ -6,7 +6,7 @@ ports:
 
 container:
   command: ComposePostService
-  image: yg397/social-network-microservices
+  image: deathstarbench/social-network-microservices
   name: compose-post-service
   ports: 
   - containerPort: 9090

--- a/socialNetwork/helm-chart/socialnetwork/charts/home-timeline-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/home-timeline-service/values.yaml
@@ -6,7 +6,7 @@ ports:
 
 container:
   command: HomeTimelineService
-  image: yg397/social-network-microservices
+  image: deathstarbench/social-network-microservices
   name: home-timeline-service
   ports: 
   - containerPort: 9090

--- a/socialNetwork/helm-chart/socialnetwork/charts/media-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/media-service/values.yaml
@@ -6,7 +6,7 @@ ports:
 
 container:
   command: MediaService
-  image: yg397/social-network-microservices
+  image: deathstarbench/social-network-microservices
   name: media-service
   ports: 
   - containerPort: 9090

--- a/socialNetwork/helm-chart/socialnetwork/charts/post-storage-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/post-storage-service/values.yaml
@@ -6,7 +6,7 @@ ports:
 
 container:
   command: PostStorageService
-  image: yg397/social-network-microservices
+  image: deathstarbench/social-network-microservices
   name: post-storage-service
   ports: 
   - containerPort: 9090

--- a/socialNetwork/helm-chart/socialnetwork/charts/social-graph-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/social-graph-service/values.yaml
@@ -6,7 +6,7 @@ ports:
 
 container:
   command: SocialGraphService
-  image: yg397/social-network-microservices
+  image: deathstarbench/social-network-microservices
   name: social-graph-service
   ports: 
   - containerPort: 9090

--- a/socialNetwork/helm-chart/socialnetwork/charts/text-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/text-service/values.yaml
@@ -6,7 +6,7 @@ ports:
 
 container:
   command: TextService
-  image: yg397/social-network-microservices
+  image: deathstarbench/social-network-microservices
   name: text-service
   ports: 
   - containerPort: 9090

--- a/socialNetwork/helm-chart/socialnetwork/charts/unique-id-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/unique-id-service/values.yaml
@@ -6,7 +6,7 @@ ports:
 
 container:
   command: UniqueIdService
-  image: yg397/social-network-microservices
+  image: deathstarbench/social-network-microservices
   name: unique-id-service
   ports: 
   - containerPort: 9090

--- a/socialNetwork/helm-chart/socialnetwork/charts/url-shorten-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/url-shorten-service/values.yaml
@@ -6,7 +6,7 @@ ports:
  
 container:
   command: UrlShortenService
-  image: yg397/social-network-microservices
+  image: deathstarbench/social-network-microservices
   name: url-shorten-service
   ports: 
   - containerPort: 9090

--- a/socialNetwork/helm-chart/socialnetwork/charts/user-mention-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/user-mention-service/values.yaml
@@ -6,7 +6,7 @@ ports:
 
 container:
   command: UserMentionService
-  image: yg397/social-network-microservices
+  image: deathstarbench/social-network-microservices
   name: user-mention-service
   ports: 
   - containerPort: 9090

--- a/socialNetwork/helm-chart/socialnetwork/charts/user-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/user-service/values.yaml
@@ -6,7 +6,7 @@ ports:
 
 container:
   command: UserService
-  image: yg397/social-network-microservices
+  image: deathstarbench/social-network-microservices
   name: user-service
   ports: 
   - containerPort: 9090

--- a/socialNetwork/helm-chart/socialnetwork/charts/user-timeline-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/user-timeline-service/values.yaml
@@ -6,7 +6,7 @@ ports:
 
 container:
   command: UserTimelineService
-  image: yg397/social-network-microservices
+  image: deathstarbench/social-network-microservices
   name: user-timeline-service
   ports: 
   - containerPort: 9090

--- a/socialNetwork/openshift/compose-post-service.yaml
+++ b/socialNetwork/openshift/compose-post-service.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
       - name: compose-post-service
-        image: yg397/social-network-microservices
+        image: deathstarbench/social-network-microservices
         command: ["ComposePostService"]
         volumeMounts:
           - mountPath: /social-network-microservices/config/jaeger-config.yml

--- a/socialNetwork/openshift/home-timeline-service.yaml
+++ b/socialNetwork/openshift/home-timeline-service.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: home-timeline-service
-        image: yg397/social-network-microservices
+        image: deathstarbench/social-network-microservices
         command: ["HomeTimelineService"]
         volumeMounts:
           - mountPath: /social-network-microservices/config/jaeger-config.yml

--- a/socialNetwork/openshift/media-service.yaml
+++ b/socialNetwork/openshift/media-service.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: media-service
-        image: yg397/social-network-microservices
+        image: deathstarbench/social-network-microservices
         command: ["MediaService"]
         volumeMounts:
           - mountPath: /social-network-microservices/config/jaeger-config.yml

--- a/socialNetwork/openshift/post-storage-service.yaml
+++ b/socialNetwork/openshift/post-storage-service.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: post-storage-service
-        image: yg397/social-network-microservices
+        image: deathstarbench/social-network-microservices
         command: ["PostStorageService"]
         ports:
         - containerPort: 9090

--- a/socialNetwork/openshift/social-graph-service.yaml
+++ b/socialNetwork/openshift/social-graph-service.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: social-graph-service
-        image: yg397/social-network-microservices
+        image: deathstarbench/social-network-microservices
         command: ["SocialGraphService"]
         volumeMounts:
           - mountPath: /social-network-microservices/config/jaeger-config.yml

--- a/socialNetwork/openshift/text-service.yaml
+++ b/socialNetwork/openshift/text-service.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: text-service
-        image: yg397/social-network-microservices
+        image: deathstarbench/social-network-microservices
         command: ["TextService"]
         volumeMounts:
           - mountPath: /social-network-microservices/config/jaeger-config.yml

--- a/socialNetwork/openshift/unique-id-service.yaml
+++ b/socialNetwork/openshift/unique-id-service.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: unique-id-service
-        image: yg397/social-network-microservices
+        image: deathstarbench/social-network-microservices
         command: ["UniqueIdService"]
         volumeMounts:
           - mountPath: /social-network-microservices/config/jaeger-config.yml

--- a/socialNetwork/openshift/url-shorten-service.yaml
+++ b/socialNetwork/openshift/url-shorten-service.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: url-shorten-service
-        image: yg397/social-network-microservices
+        image: deathstarbench/social-network-microservices
         command: ["UrlShortenService"]
         volumeMounts:
           - mountPath: /social-network-microservices/config/jaeger-config.yml

--- a/socialNetwork/openshift/user-mention-service.yaml
+++ b/socialNetwork/openshift/user-mention-service.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: user-mention-service
-        image: yg397/social-network-microservices
+        image: deathstarbench/social-network-microservices
         command: ["UserMentionService"]
         volumeMounts:
           - mountPath: /social-network-microservices/config/jaeger-config.yml

--- a/socialNetwork/openshift/user-service.yaml
+++ b/socialNetwork/openshift/user-service.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: user-service
-        image: yg397/social-network-microservices
+        image: deathstarbench/social-network-microservices
         command: ["UserService"]
         volumeMounts:
           - mountPath: /social-network-microservices/config/jaeger-config.yml

--- a/socialNetwork/openshift/user-timeline-service.yaml
+++ b/socialNetwork/openshift/user-timeline-service.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: user-timeline-service
-        image: yg397/social-network-microservices
+        image: deathstarbench/social-network-microservices
         command: ["UserTimelineService"]
         volumeMounts:
           - mountPath: /social-network-microservices/config/jaeger-config.yml

--- a/socialNetwork/openshift/write-home-timeline-service.yaml
+++ b/socialNetwork/openshift/write-home-timeline-service.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
       - name: write-home-timeline-service
-        image: yg397/social-network-microservices
+        image: deathstarbench/social-network-microservices
         command: ["WriteHomeTimelineService"]
         volumeMounts:
           - mountPath: /social-network-microservices/config/jaeger-config.yml


### PR DESCRIPTION
Replace old and outdated social-network Docker image references with new, versioned images prepared  with CI pipeline.﻿
