### PR TITLE
fix: hotelReservation README file subheading typo

### DIFF
--- a/hotelReservation/README.md
+++ b/hotelReservation/README.md
@@ -17,7 +17,7 @@ Supported actions:
 - luarocks (apt-get install luarocks)
 - luasocket (luarocks install luasocket)
 
-## Running the social network application
+## Running the hotel reservation application
 ### Before you start
 - Install Docker and Docker Compose.
 - Make sure exposed ports in docker-compose files are available


### PR DESCRIPTION
First of all, thanks for the benchmark. I believe that there is a small typo in the hotel reservation README file, where it states: "Running the social network application" should be "Running the hotel reservation application"

Thank you,
