### PR TITLE
github actions: Add concurrency control

### DIFF
--- a/.github/workflows/hotelreservation-push.yaml
+++ b/.github/workflows/hotelreservation-push.yaml
@@ -1,4 +1,5 @@
 name: Push HotelReservation
+concurrency: ci-hotelReservation
 
 on:
   push:

--- a/.github/workflows/socialnetwork-push.yaml
+++ b/.github/workflows/socialnetwork-push.yaml
@@ -1,4 +1,5 @@
 name: Push SocialNetwork
+concurrency: ci-socialNetwork
 
 on:
   push: 


### PR DESCRIPTION
Add concurrency control to avoid tagging failure when multiple parallel runs.

Fixed issue #250.