### PR TITLE
Add knative workload examples

### DIFF
--- a/hotelReservation/cmd/frontend/main.go
+++ b/hotelReservation/cmd/frontend/main.go
@@ -34,6 +34,7 @@ func main() {
 
 	serv_port, _ := strconv.Atoi(result["FrontendPort"])
 	serv_ip := result["FrontendIP"]
+	knative_dns := result["KnativeDomainName"]
 
 	log.Info().Msgf("Read target port: %v", serv_port)
 	log.Info().Msgf("Read consul address: %v", result["consulAddress"])
@@ -59,10 +60,11 @@ func main() {
 	log.Info().Msg("Consul agent initialized")
 
 	srv := &frontend.Server{
-		Registry: registry,
-		Tracer:   tracer,
-		IpAddr:   serv_ip,
-		Port:     serv_port,
+		KnativeDns: knative_dns,
+		Registry:   registry,
+		Tracer:     tracer,
+		IpAddr:     serv_ip,
+		Port:       serv_port,
 	}
 
 	log.Info().Msg("Starting server...")

--- a/hotelReservation/cmd/search/main.go
+++ b/hotelReservation/cmd/search/main.go
@@ -36,6 +36,7 @@ func main() {
 
 	serv_port, _ := strconv.Atoi(result["SearchPort"])
 	serv_ip := result["SearchIP"]
+	knative_dns := result["KnativeDomainName"]
 	log.Info().Msgf("Read target port: %v", serv_port)
 	log.Info().Msgf("Read consul address: %v", result["consulAddress"])
 	log.Info().Msgf("Read jaeger address: %v", result["jaegerAddress"])
@@ -64,9 +65,10 @@ func main() {
 	srv := &search.Server{
 		Tracer: tracer,
 		// Port:     *port,
-		Port:     serv_port,
-		IpAddr:   serv_ip,
-		Registry: registry,
+		Port:       serv_port,
+		IpAddr:     serv_ip,
+		KnativeDns: knative_dns,
+		Registry:   registry,
 	}
 
 	log.Info().Msg("Starting server...")

--- a/hotelReservation/config.json
+++ b/hotelReservation/config.json
@@ -17,5 +17,6 @@
   "ReserveMemcAddress": "memcached-reserve:11211",
   "SearchPort": "8082",
   "UserPort": "8086",
-  "UserMongoAddress": "mongodb-user:27017"
+  "UserMongoAddress": "mongodb-user:27017",
+  "KnativeDomainName":  "default.10.108.189.25.sslip.io:80"
 }

--- a/hotelReservation/knative/consul-deployment.yaml
+++ b/hotelReservation/knative/consul-deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: consul
+  name: consul
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: consul
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.22.0 (955b78124)
+        sidecar.istio.io/statsInclusionPrefixes: cluster.outbound,cluster_manager,listener_manager,http_mixer_filter,tcp_mixer_filter,server,cluster.xds-grp,listener,connection_manager
+        sidecar.istio.io/statsInclusionRegexps: http.*
+      creationTimestamp: null
+      labels:
+        io.kompose.service: consul
+    spec:
+      containers:
+        - image: consul:latest
+          name: consul
+          ports:
+            - containerPort: 8300
+            - containerPort: 8400
+            - containerPort: 8500
+            - containerPort: 53
+              protocol: UDP
+          resources:
+            requests:
+              cpu: 100m
+            limits:
+              cpu: 1000m
+      restartPolicy: Always
+status: {}

--- a/hotelReservation/knative/consul-service.yaml
+++ b/hotelReservation/knative/consul-service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: consul
+  name: consul
+spec:
+  ports:
+    - name: "8300"
+      port: 8300
+      targetPort: 8300
+    - name: "8400"
+      port: 8400
+      targetPort: 8400
+    - name: "8500"
+      port: 8500
+      targetPort: 8500
+    - name: "8600"
+      port: 8600
+      protocol: UDP
+      targetPort: 53
+  selector:
+    io.kompose.service: consul
+status:
+  loadBalancer: {}

--- a/hotelReservation/knative/frontend-deployment.yaml
+++ b/hotelReservation/knative/frontend-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: frontend
+  name: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: frontend
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.22.0 (955b78124)
+        sidecar.istio.io/statsInclusionPrefixes: cluster.outbound,cluster_manager,listener_manager,http_mixer_filter,tcp_mixer_filter,server,cluster.xds-grp,listener,connection_manager
+        sidecar.istio.io/statsInclusionRegexps: http.*
+      creationTimestamp: null
+      labels:
+        io.kompose.service: frontend
+    spec:
+      containers:
+        - command:
+            - frontend
+          image: igorrudyk1/hotelreservation:latest
+          name: hotel-reserv-frontend
+          ports:
+            - containerPort: 5000
+          resources:
+            requests:
+              cpu: 100m
+            limits:
+              cpu: 1000m
+      restartPolicy: Always
+status: {}

--- a/hotelReservation/knative/frontend-deployment.yaml
+++ b/hotelReservation/knative/frontend-deployment.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - command:
             - frontend
-          image: igorrudyk1/hotelreservation:latest
+          image: teresaliuchang/hotel_demo:v1.7
           name: hotel-reserv-frontend
           ports:
             - containerPort: 5000

--- a/hotelReservation/knative/frontend-service.yaml
+++ b/hotelReservation/knative/frontend-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: frontend
+  name: frontend
+spec:
+  ports:
+    - name: "5000"
+      port: 5000
+      targetPort: 5000
+  selector:
+    io.kompose.service: frontend
+status:
+  loadBalancer: {}

--- a/hotelReservation/knative/geo-persistent-volume.yaml
+++ b/hotelReservation/knative/geo-persistent-volume.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: geo-pv
+spec:
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  storageClassName: geo-storage
+  hostPath:
+    path: /data/volumes/geo-pv   # Where all the hard drives are mounted
+    type: DirectoryOrCreate

--- a/hotelReservation/knative/geo-pvc.yaml
+++ b/hotelReservation/knative/geo-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: geo-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: geo-storage
+  resources:
+    requests:
+      storage: 1Gi

--- a/hotelReservation/knative/jaeger-deployment.yaml
+++ b/hotelReservation/knative/jaeger-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: jaeger
+  name: jaeger
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: jaeger
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.22.0 (955b78124)
+        sidecar.istio.io/statsInclusionPrefixes: cluster.outbound,cluster_manager,listener_manager,http_mixer_filter,tcp_mixer_filter,server,cluster.xds-grp,listener,connection_manager
+        sidecar.istio.io/statsInclusionRegexps: http.*
+      creationTimestamp: null
+      labels:
+        io.kompose.service: jaeger
+    spec:
+      containers:
+        - image: jaegertracing/all-in-one:latest
+          name: hotel-reserv-jaeger
+          ports:
+            - containerPort: 14269
+            - containerPort: 5778
+            - containerPort: 14268
+            - containerPort: 14267
+            - containerPort: 16686
+            - containerPort: 5775
+              protocol: UDP
+            - containerPort: 6831
+              protocol: UDP
+            - containerPort: 6832
+              protocol: UDP
+          resources:
+            requests:
+              cpu: 100m
+            limits:
+              cpu: 1000m
+      restartPolicy: Always
+status: {}

--- a/hotelReservation/knative/jaeger-service.yaml
+++ b/hotelReservation/knative/jaeger-service.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: jaeger
+  name: jaeger
+spec:
+  ports:
+    - name: "14269"
+      port: 14269
+      targetPort: 14269
+    - name: "5778"
+      port: 5778
+      targetPort: 5778
+    - name: "14268"
+      port: 14268
+      targetPort: 14268
+    - name: "14267"
+      port: 14267
+      targetPort: 14267
+    - name: "16686"
+      port: 16686
+      targetPort: 16686
+    - name: "5775"
+      port: 5775
+      protocol: UDP
+      targetPort: 5775
+    - name: "6831"
+      port: 6831
+      protocol: UDP
+      targetPort: 6831
+    - name: "6832"
+      port: 6832
+      protocol: UDP
+      targetPort: 6832
+  selector:
+    io.kompose.service: jaeger
+status:
+  loadBalancer: {}

--- a/hotelReservation/knative/memcached-profile-deployment.yaml
+++ b/hotelReservation/knative/memcached-profile-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: memcached-profile
+  name: memcached-profile
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: memcached-profile
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.22.0 (955b78124)
+        sidecar.istio.io/statsInclusionPrefixes: cluster.outbound,cluster_manager,listener_manager,http_mixer_filter,tcp_mixer_filter,server,cluster.xds-grp,listener,connection_manager
+        sidecar.istio.io/statsInclusionRegexps: http.*
+      creationTimestamp: null
+      labels:
+        io.kompose.service: memcached-profile
+    spec:
+      containers:
+        - env:
+            - name: MEMCACHED_CACHE_SIZE
+              value: "128"
+            - name: MEMCACHED_THREADS
+              value: "2"
+          image: memcached
+          name: hotel-reserv-profile-mmc
+          ports:
+            - containerPort: 11211
+          resources:
+            requests:
+              cpu: 100m
+            limits:
+              cpu: 1000m
+      restartPolicy: Always
+status: {}

--- a/hotelReservation/knative/memcached-profile-service.yaml
+++ b/hotelReservation/knative/memcached-profile-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: memcached-profile
+  name: memcached-profile
+spec:
+  ports:
+    - name: "memcached-profile"
+      port: 11211
+      targetPort: 11211
+  selector:
+    io.kompose.service: memcached-profile
+status:
+  loadBalancer: {}

--- a/hotelReservation/knative/memcached-rate-deployment.yaml
+++ b/hotelReservation/knative/memcached-rate-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: memcached-rate
+  name: memcached-rate
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: memcached-rate
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.22.0 (955b78124)
+        sidecar.istio.io/statsInclusionPrefixes: cluster.outbound,cluster_manager,listener_manager,http_mixer_filter,tcp_mixer_filter,server,cluster.xds-grp,listener,connection_manager
+        sidecar.istio.io/statsInclusionRegexps: http.*
+      creationTimestamp: null
+      labels:
+        io.kompose.service: memcached-rate
+    spec:
+      containers:
+        - env:
+            - name: MEMCACHED_CACHE_SIZE
+              value: "128"
+            - name: MEMCACHED_THREADS
+              value: "2"
+          image: memcached
+          name: hotel-reserv-rate-mmc
+          ports:
+            - containerPort: 11211
+          resources:
+            requests:
+              cpu: 100m
+            limits:
+              cpu: 1000m
+      restartPolicy: Always
+status: {}

--- a/hotelReservation/knative/memcached-rate-service.yaml
+++ b/hotelReservation/knative/memcached-rate-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: memcached-rate
+  name: memcached-rate
+spec:
+  ports:
+    - name: "memcached-rate"
+      port: 11211
+      targetPort: 11211
+  selector:
+    io.kompose.service: memcached-rate
+status:
+  loadBalancer: {}

--- a/hotelReservation/knative/memcached-reservation-deployment.yaml
+++ b/hotelReservation/knative/memcached-reservation-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: memcached-reserve
+  name: memcached-reserve
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: memcached-reserve
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.22.0 (955b78124)
+        sidecar.istio.io/statsInclusionPrefixes: cluster.outbound,cluster_manager,listener_manager,http_mixer_filter,tcp_mixer_filter,server,cluster.xds-grp,listener,connection_manager
+        sidecar.istio.io/statsInclusionRegexps: http.*
+      creationTimestamp: null
+      labels:
+        io.kompose.service: memcached-reserve
+    spec:
+      containers:
+        - env:
+            - name: MEMCACHED_CACHE_SIZE
+              value: "128"
+            - name: MEMCACHED_THREADS
+              value: "2"
+          image: memcached
+          name: hotel-reserv-reservation-mmc
+          ports:
+            - containerPort: 11211
+          resources:
+            requests:
+              cpu: 100m
+            limits:
+              cpu: 1000m
+      restartPolicy: Always
+status: {}

--- a/hotelReservation/knative/memcached-reservation-service.yaml
+++ b/hotelReservation/knative/memcached-reservation-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: memcached-reserve
+  name: memcached-reserve
+spec:
+  ports:
+    - name: "memcached-reserve"
+      port: 11211
+      targetPort: 11211
+  selector:
+    io.kompose.service: memcached-reserve
+status:
+  loadBalancer: {}

--- a/hotelReservation/knative/mongodb-geo-deployment.yaml
+++ b/hotelReservation/knative/mongodb-geo-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: mongodb-geo
+  name: mongodb-geo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: mongodb-geo
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.22.0 (955b78124)
+        sidecar.istio.io/statsInclusionPrefixes: cluster.outbound,cluster_manager,listener_manager,http_mixer_filter,tcp_mixer_filter,server,cluster.xds-grp,listener,connection_manager
+        sidecar.istio.io/statsInclusionRegexps: http.*
+      creationTimestamp: null
+      labels:
+        io.kompose.service: mongodb-geo
+    spec:
+      containers:
+        - image: mongo:4.4.6
+          name: hotel-reserv-geo-mongo
+          ports:
+            - containerPort: 27017
+          resources:
+            requests:
+              cpu: 100m
+            limits:
+              cpu: 1000m
+          volumeMounts:
+            - mountPath: /data/db
+              name: geo
+      restartPolicy: Always
+      volumes:
+        - name: geo
+          persistentVolumeClaim:
+            claimName: geo-pvc
+status: {}

--- a/hotelReservation/knative/mongodb-geo-service.yaml
+++ b/hotelReservation/knative/mongodb-geo-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: mongodb-geo
+  name: mongodb-geo
+spec:
+  ports:
+    - name: "mongodb-geo"
+      port: 27017
+      targetPort: 27017
+  selector:
+    io.kompose.service: mongodb-geo
+status:
+  loadBalancer: {}

--- a/hotelReservation/knative/mongodb-profile-deployment.yaml
+++ b/hotelReservation/knative/mongodb-profile-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: mongodb-profile
+  name: mongodb-profile
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: mongodb-profile
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.22.0 (955b78124)
+        sidecar.istio.io/statsInclusionPrefixes: cluster.outbound,cluster_manager,listener_manager,http_mixer_filter,tcp_mixer_filter,server,cluster.xds-grp,listener,connection_manager
+        sidecar.istio.io/statsInclusionRegexps: http.*
+      creationTimestamp: null
+      labels:
+        io.kompose.service: mongodb-profile
+    spec:
+      containers:
+        - image: mongo:4.4.6
+          name: hotel-reserv-profile-mongo
+          ports:
+            - containerPort: 27017
+          resources:
+            requests:
+              cpu: 100m
+            limits:
+              cpu: 1000m
+          volumeMounts:
+            - mountPath: /data/db
+              name: profile
+      hostname: profile-db
+      restartPolicy: Always
+      volumes:
+        - name: profile
+          persistentVolumeClaim:
+            claimName: profile-pvc
+status: {}

--- a/hotelReservation/knative/mongodb-profile-service.yaml
+++ b/hotelReservation/knative/mongodb-profile-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: mongodb-profile
+  name: mongodb-profile
+spec:
+  ports:
+    - name: "mongodb-profile"
+      port: 27017
+      targetPort: 27017
+  selector:
+    io.kompose.service: mongodb-profile
+status:
+  loadBalancer: {}

--- a/hotelReservation/knative/mongodb-rate-deployment.yaml
+++ b/hotelReservation/knative/mongodb-rate-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: mongodb-rate
+  name: mongodb-rate
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: mongodb-rate
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.22.0 (955b78124)
+        sidecar.istio.io/statsInclusionPrefixes: cluster.outbound,cluster_manager,listener_manager,http_mixer_filter,tcp_mixer_filter,server,cluster.xds-grp,listener,connection_manager
+        sidecar.istio.io/statsInclusionRegexps: http.*
+      creationTimestamp: null
+      labels:
+        io.kompose.service: mongodb-rate
+    spec:
+      containers:
+        - image: mongo:4.4.6
+          name: hotel-reserv-rate-mongo
+          ports:
+            - containerPort: 27017
+          resources:
+            requests:
+              cpu: 100m
+            limits:
+              cpu: 1000m
+          volumeMounts:
+            - mountPath: /data/db
+              name: rate
+      restartPolicy: Always
+      volumes:
+        - name: rate
+          persistentVolumeClaim:
+            claimName: rate-pvc
+status: {}

--- a/hotelReservation/knative/mongodb-rate-service.yaml
+++ b/hotelReservation/knative/mongodb-rate-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: mongodb-rate
+  name: mongodb-rate
+spec:
+  ports:
+    - name: "mongodb-rate"
+      port: 27017
+      targetPort: 27017
+  selector:
+    io.kompose.service: mongodb-rate
+status:
+  loadBalancer: {}

--- a/hotelReservation/knative/mongodb-recommendation-deployment.yaml
+++ b/hotelReservation/knative/mongodb-recommendation-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: mongodb-recommendation
+  name: mongodb-recommendation
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: mongodb-recommendation
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.22.0 (955b78124)
+        sidecar.istio.io/statsInclusionPrefixes: cluster.outbound,cluster_manager,listener_manager,http_mixer_filter,tcp_mixer_filter,server,cluster.xds-grp,listener,connection_manager
+        sidecar.istio.io/statsInclusionRegexps: http.*
+      creationTimestamp: null
+      labels:
+        io.kompose.service: mongodb-recommendation
+    spec:
+      containers:
+        - image: mongo:4.4.6
+          name: hotel-reserv-recommendation-mongo
+          ports:
+            - containerPort: 27017
+          resources:
+            requests:
+              cpu: 100m
+            limits:
+              cpu: 1000m
+          volumeMounts:
+            - mountPath: /data/db
+              name: recommendation
+      hostname: recommendation-db
+      restartPolicy: Always
+      volumes:
+        - name: recommendation
+          persistentVolumeClaim:
+            claimName: recommendation-pvc
+status: {}

--- a/hotelReservation/knative/mongodb-recommendation-service.yaml
+++ b/hotelReservation/knative/mongodb-recommendation-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: mongodb-recommendation
+  name: mongodb-recommendation
+spec:
+  ports:
+    - name: "mongodb-recommendation"
+      port: 27017
+      targetPort: 27017
+  selector:
+    io.kompose.service: mongodb-recommendation
+status:
+  loadBalancer: {}

--- a/hotelReservation/knative/mongodb-reservation-deployment.yaml
+++ b/hotelReservation/knative/mongodb-reservation-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: mongodb-reservation
+  name: mongodb-reservation
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: mongodb-reservation
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.22.0 (955b78124)
+        sidecar.istio.io/statsInclusionPrefixes: cluster.outbound,cluster_manager,listener_manager,http_mixer_filter,tcp_mixer_filter,server,cluster.xds-grp,listener,connection_manager
+        sidecar.istio.io/statsInclusionRegexps: http.*
+      creationTimestamp: null
+      labels:
+        io.kompose.service: mongodb-reservation
+    spec:
+      containers:
+        - image: mongo:4.4.6
+          name: hotel-reserv-reservation-mongo
+          ports:
+            - containerPort: 27017
+          resources:
+            requests:
+              cpu: 100m
+            limits:
+              cpu: 1000m
+          volumeMounts:
+            - mountPath: /data/db
+              name: reservation
+      hostname: reservation-db
+      restartPolicy: Always
+      volumes:
+        - name: reservation
+          persistentVolumeClaim:
+            claimName: reservation-pvc
+status: {}

--- a/hotelReservation/knative/mongodb-reservation-service.yaml
+++ b/hotelReservation/knative/mongodb-reservation-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: mongodb-reservation
+  name: mongodb-reservation
+spec:
+  ports:
+    - name: "mongodb-reservation"
+      port: 27017
+      targetPort: 27017
+  selector:
+    io.kompose.service: mongodb-reservation
+status:
+  loadBalancer: {}

--- a/hotelReservation/knative/mongodb-user-deployment.yaml
+++ b/hotelReservation/knative/mongodb-user-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: mongodb-user
+  name: mongodb-user
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: mongodb-user
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.22.0 (955b78124)
+        sidecar.istio.io/statsInclusionPrefixes: cluster.outbound,cluster_manager,listener_manager,http_mixer_filter,tcp_mixer_filter,server,cluster.xds-grp,listener,connection_manager
+        sidecar.istio.io/statsInclusionRegexps: http.*
+      creationTimestamp: null
+      labels:
+        io.kompose.service: mongodb-user
+    spec:
+      containers:
+        - image: mongo:4.4.6
+          name: hotel-reserv-user-mongo
+          ports:
+            - containerPort: 27017
+          resources:
+            requests:
+              cpu: 100m
+            limits:
+              cpu: 1000m
+          volumeMounts:
+            - mountPath: /data/db
+              name: user
+      hostname: user-db
+      restartPolicy: Always
+      volumes:
+        - name: user
+          persistentVolumeClaim:
+            claimName: user-pvc
+status: {}

--- a/hotelReservation/knative/mongodb-user-service.yaml
+++ b/hotelReservation/knative/mongodb-user-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (955b78124)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: mongodb-user
+  name: mongodb-user
+spec:
+  ports:
+    - name: "mongodb-user"
+      port: 27017
+      targetPort: 27017
+  selector:
+    io.kompose.service: mongodb-user
+status:
+  loadBalancer: {}

--- a/hotelReservation/knative/profile-persistent-volume.yaml
+++ b/hotelReservation/knative/profile-persistent-volume.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: profile-pv
+spec:
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  storageClassName: profile-storage
+  hostPath:
+    path: /data/volumes/profile-pv   # Where all the hard drives are mounted
+    type: DirectoryOrCreate

--- a/hotelReservation/knative/profile-pvc.yaml
+++ b/hotelReservation/knative/profile-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: profile-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: profile-storage
+  resources:
+    requests:
+      storage: 1Gi

--- a/hotelReservation/knative/rate-persistent-volume.yaml
+++ b/hotelReservation/knative/rate-persistent-volume.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: rate-pv
+spec:
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  storageClassName: rate-storage
+  hostPath:
+    path: /data/volumes/rate-pv   # Where all the hard drives are mounted
+    type: DirectoryOrCreate

--- a/hotelReservation/knative/rate-pvc.yaml
+++ b/hotelReservation/knative/rate-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rate-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: rate-storage
+  resources:
+    requests:
+      storage: 1Gi

--- a/hotelReservation/knative/recommendation-persistent-volume.yaml
+++ b/hotelReservation/knative/recommendation-persistent-volume.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: recommendation-pv
+spec:
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  storageClassName: recommendation-storage
+  hostPath:
+    path: /data/volumes/recommendation-pv   # Where all the hard drives are mounted
+    type: DirectoryOrCreate

--- a/hotelReservation/knative/recommendation-pvc.yaml
+++ b/hotelReservation/knative/recommendation-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: recommendation-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: recommendation-storage
+  resources:
+    requests:
+      storage: 1Gi

--- a/hotelReservation/knative/reservation-persistent-volume.yaml
+++ b/hotelReservation/knative/reservation-persistent-volume.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: reservation-pv
+spec:
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  storageClassName: reservation-storage
+  hostPath:
+    path: /data/volumes/reservation-pv   # Where all the hard drives are mounted
+    type: DirectoryOrCreate

--- a/hotelReservation/knative/reservation-pvc.yaml
+++ b/hotelReservation/knative/reservation-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: reservation-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: reservation-storage
+  resources:
+    requests:
+      storage: 1Gi

--- a/hotelReservation/knative/scripts/deploy-knative-svc.sh
+++ b/hotelReservation/knative/scripts/deploy-knative-svc.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+
+cd $(dirname $0)/..
+
+for i in *.yaml
+do
+  kubectl apply -f ${i}  &
+done
+wait
+sleep 30
+
+kubectl apply -f svc/  &
+
+echo "Finishing in 30 seconds"
+sleep 30
+
+kubectl get pods
+
+cd - >/dev/null

--- a/hotelReservation/knative/scripts/update-config.sh
+++ b/hotelReservation/knative/scripts/update-config.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+
+cd $(dirname $0)/../../
+
+istioIngress=$(kubectl get svc -n istio-system | grep "istio-ingressgateway" | awk '{print $3}')
+namespace=default.
+domainName=.sslip.io:80
+
+
+if [ `grep -c "KnativeDomainName" "config.json"` -ne '0' ];then
+    echo "Append config: KnativeDomainName"
+    sed -i '/"KnativeDomainName"/c\  \"KnativeDomainName\": \"'$namespace$istioIngress$domainName'\"'  config.json
+    exit 0
+fi
+
+sed -i '/"UserMongoAddress"/ s/$/&,/' config.json
+sed -i '$i\  "KnativeDomainName\": \"'$namespace$istioIngress$domainName'\"'  config.json
+
+
+

--- a/hotelReservation/knative/svc/srv-geo.yaml
+++ b/hotelReservation/knative/svc/srv-geo.yaml
@@ -1,0 +1,23 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: srv-geo
+spec:
+  template:
+    spec:
+      containers:
+      - command:
+        - geo
+        env:
+        - name: DLOG
+          value: DEBUG
+        image: teresaliuchang/hotel_demo:v1.7
+        name: hotel-reserv-geo
+        ports:
+          - name: h2c
+            containerPort: 8081
+        resources:
+          requests:
+            cpu: 100m
+          limits:
+            cpu: 1000m

--- a/hotelReservation/knative/svc/srv-profile.yaml
+++ b/hotelReservation/knative/svc/srv-profile.yaml
@@ -1,0 +1,23 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: srv-profile
+spec:
+  template:
+    spec:
+      containers:
+      - command:
+        - profile
+        env:
+        - name: DLOG
+          value: DEBUG
+        image: teresaliuchang/hotel_demo:v1.7
+        name: hotel-reserv-profile
+        ports:
+          - name: h2c
+            containerPort: 8081
+        resources:
+          requests:
+            cpu: 100m
+          limits:
+            cpu: 1000m

--- a/hotelReservation/knative/svc/srv-rate.yaml
+++ b/hotelReservation/knative/svc/srv-rate.yaml
@@ -1,0 +1,24 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: srv-rate
+spec:
+  template:
+    spec:
+      containerConcurrency: 20
+      containers:
+      - command:
+        - rate
+        env:
+        - name: DLOG
+          value: DEBUG
+        image: teresaliuchang/hotel_demo:v1.7
+        name: hotel-reserv-rate
+        ports:
+          - name: h2c
+            containerPort: 8086
+        resources:
+          requests:
+            cpu: 100m
+          limits:
+            cpu: 1000m

--- a/hotelReservation/knative/svc/srv-recommendation.yaml
+++ b/hotelReservation/knative/svc/srv-recommendation.yaml
@@ -1,0 +1,24 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: srv-recommendation
+spec:
+  template:
+    spec:
+      containerConcurrency: 20
+      containers:
+      - command:
+        - recommendation
+        env:
+        - name: DLOG
+          value: DEBUG
+        image: teresaliuchang/hotel_demo:v1.7
+        name: hotel-reserv-recommendation
+        ports:
+          - name: h2c
+            containerPort: 8086
+        resources:
+          requests:
+            cpu: 100m
+          limits:
+            cpu: 1000m

--- a/hotelReservation/knative/svc/srv-reservation.yaml
+++ b/hotelReservation/knative/svc/srv-reservation.yaml
@@ -1,0 +1,24 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: srv-reservation
+spec:
+  template:
+    spec:
+      containerConcurrency: 20
+      containers:
+      - command:
+        - reservation
+        env:
+        - name: DLOG
+          value: DEBUG
+        image: teresaliuchang/hotel_demo:v1.7
+        name: hotel-reserv-reservation
+        ports:
+          - name: h2c
+            containerPort: 8086
+        resources:
+          requests:
+            cpu: 100m
+          limits:
+            cpu: 1000m

--- a/hotelReservation/knative/svc/srv-search.yaml
+++ b/hotelReservation/knative/svc/srv-search.yaml
@@ -1,0 +1,24 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: srv-search
+spec:
+  template:
+    spec:
+      containerConcurrency: 20
+      containers:
+      - command:
+        - search
+        env:
+        - name: DLOG
+          value: DEBUG
+        image: teresaliuchang/hotel_demo:v1.7
+        name: hotel-reserv-search
+        ports:
+          - name: h2c
+            containerPort: 8086
+        resources:
+          requests:
+            cpu: 100m
+          limits:
+            cpu: 1000m

--- a/hotelReservation/knative/svc/srv-user.yaml
+++ b/hotelReservation/knative/svc/srv-user.yaml
@@ -1,0 +1,24 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: srv-user
+spec:
+  template:
+    spec:
+      containerConcurrency: 20
+      containers:
+      - command:
+        - user
+        env:
+        - name: DLOG
+          value: DEBUG
+        image: teresaliuchang/hotel_demo:v1.7
+        name: hotel-reserv-user
+        ports:
+          - name: h2c
+            containerPort: 8086
+        resources:
+          requests:
+            cpu: 100m
+          limits:
+            cpu: 1000m

--- a/hotelReservation/knative/user-persistent-volume.yaml
+++ b/hotelReservation/knative/user-persistent-volume.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: user-pv
+spec:
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  storageClassName: user-storage
+  hostPath:
+    path: /data/volumes/user-pv   # Where all the hard drives are mounted
+    type: DirectoryOrCreate

--- a/hotelReservation/knative/user-pvc.yaml
+++ b/hotelReservation/knative/user-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: user-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: user-storage
+  resources:
+    requests:
+      storage: 1Gi

--- a/hotelReservation/services/frontend/server.go
+++ b/hotelReservation/services/frontend/server.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"google.golang.org/grpc"
+
 	recommendation "github.com/harlow/go-micro-services/services/recommendation/proto"
 	reservation "github.com/harlow/go-micro-services/services/reservation/proto"
 	user "github.com/harlow/go-micro-services/services/user/proto"
@@ -27,6 +29,7 @@ type Server struct {
 	recommendationClient recommendation.RecommendationClient
 	userClient           user.UserClient
 	reservationClient    reservation.ReservationClient
+	KnativeDns           string
 	IpAddr               string
 	Port                 int
 	Tracer               opentracing.Tracer
@@ -81,17 +84,13 @@ func (s *Server) Run() error {
 		srv.TLSConfig = tlsconfig
 		return srv.ListenAndServeTLS("x509/server_cert.pem", "x509/server_key.pem")
 	} else {
-		log.Info().Msg("Serving https")
+		log.Info().Msg("Serving http")
 		return srv.ListenAndServe()
 	}
 }
 
 func (s *Server) initSearchClient(name string) error {
-	conn, err := dialer.Dial(
-		name,
-		dialer.WithTracer(s.Tracer),
-		dialer.WithBalancer(s.Registry.Client),
-	)
+	conn, err := s.getGprcConn(name)
 	if err != nil {
 		return fmt.Errorf("dialer error: %v", err)
 	}
@@ -100,11 +99,7 @@ func (s *Server) initSearchClient(name string) error {
 }
 
 func (s *Server) initProfileClient(name string) error {
-	conn, err := dialer.Dial(
-		name,
-		dialer.WithTracer(s.Tracer),
-		dialer.WithBalancer(s.Registry.Client),
-	)
+	conn, err := s.getGprcConn(name)
 	if err != nil {
 		return fmt.Errorf("dialer error: %v", err)
 	}
@@ -113,11 +108,7 @@ func (s *Server) initProfileClient(name string) error {
 }
 
 func (s *Server) initRecommendationClient(name string) error {
-	conn, err := dialer.Dial(
-		name,
-		dialer.WithTracer(s.Tracer),
-		dialer.WithBalancer(s.Registry.Client),
-	)
+	conn, err := s.getGprcConn(name)
 	if err != nil {
 		return fmt.Errorf("dialer error: %v", err)
 	}
@@ -126,11 +117,7 @@ func (s *Server) initRecommendationClient(name string) error {
 }
 
 func (s *Server) initUserClient(name string) error {
-	conn, err := dialer.Dial(
-		name,
-		dialer.WithTracer(s.Tracer),
-		dialer.WithBalancer(s.Registry.Client),
-	)
+	conn, err := s.getGprcConn(name)
 	if err != nil {
 		return fmt.Errorf("dialer error: %v", err)
 	}
@@ -139,16 +126,29 @@ func (s *Server) initUserClient(name string) error {
 }
 
 func (s *Server) initReservation(name string) error {
-	conn, err := dialer.Dial(
-		name,
-		dialer.WithTracer(s.Tracer),
-		dialer.WithBalancer(s.Registry.Client),
-	)
+	conn, err := s.getGprcConn(name)
 	if err != nil {
 		return fmt.Errorf("dialer error: %v", err)
 	}
 	s.reservationClient = reservation.NewReservationClient(conn)
 	return nil
+}
+
+func (s *Server) getGprcConn(name string) (*grpc.ClientConn, error) {
+	log.Info().Msg("get Grpc conn is :")
+	log.Info().Msg(s.KnativeDns)
+	log.Info().Msg(fmt.Sprintf("%s.%s", name, s.KnativeDns))
+	if s.KnativeDns != "" {
+		return dialer.Dial(
+			fmt.Sprintf("%s.%s", name, s.KnativeDns),
+			dialer.WithTracer(s.Tracer))
+	} else {
+		return dialer.Dial(
+			name,
+			dialer.WithTracer(s.Tracer),
+			dialer.WithBalancer(s.Registry.Client),
+		)
+	}
 }
 
 func (s *Server) searchHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
In this PR, we've proposed a `Knative examples` as `FaaS workload`
We've added some code and we make sure the original functions are not be affected
The `yamls` and corresponding `scripts` are also updated for this example