### PR TITLE
Added nodeName variable to socialNetwork helm-chart base template

### DIFF
--- a/socialNetwork/helm-chart/socialnetwork/templates/_baseDeployment.tpl
+++ b/socialNetwork/helm-chart/socialnetwork/templates/_baseDeployment.tpl
@@ -15,7 +15,10 @@ spec:
       labels:
         service: {{ .Values.name }}
         app: {{ .Values.name }}
-    spec: 
+    spec:
+      {{- if .Values.nodeName}}
+      nodeName: {{ .Values.nodeName }}
+      {{ end }}
       containers:
       {{- with .Values.container }}
       - name: "{{ .name }}"


### PR DESCRIPTION
The nodeName variable is used for pinning pods to specific nodes. 
In the case of jaeger we use it to pin Jager Pods to master node. 