### PR TITLE
Improve memcached access performance in hotelReservation

### DIFF
--- a/hotelReservation/cmd/profile/main.go
+++ b/hotelReservation/cmd/profile/main.go
@@ -42,7 +42,7 @@ func main() {
 
 	log.Info().Msgf("Read profile memcashed address: %v", result["ProfileMemcAddress"])
 	log.Info().Msg("Initializing Memcashed client...")
-	memc_client := tune.NewMemCClient(result["ProfileMemcAddress"])
+	memc_client := tune.NewMemCClient2(result["ProfileMemcAddress"])
 	log.Info().Msg("Successfull")
 
 	serv_port, _ := strconv.Atoi(result["ProfilePort"])

--- a/hotelReservation/cmd/rate/main.go
+++ b/hotelReservation/cmd/rate/main.go
@@ -42,7 +42,7 @@ func main() {
 
 	log.Info().Msgf("Read profile memcashed address: %v", result["RateMemcAddress"])
 	log.Info().Msg("Initializing Memcashed client...")
-	memc_client := tune.NewMemCClient(result["RateMemcAddress"])
+	memc_client := tune.NewMemCClient2(result["RateMemcAddress"])
 	log.Info().Msg("Successfull")
 
 	serv_port, _ := strconv.Atoi(result["RatePort"])

--- a/hotelReservation/cmd/reservation/main.go
+++ b/hotelReservation/cmd/reservation/main.go
@@ -43,7 +43,7 @@ func main() {
 
 	log.Info().Msgf("Read profile memcashed address: %v", result["ReserveMemcAddress"])
 	log.Info().Msg("Initializing Memcashed client...")
-	memc_client := tune.NewMemCClient(result["ReserveMemcAddress"])
+	memc_client := tune.NewMemCClient2(result["ReserveMemcAddress"])
 	log.Info().Msg("Successfull")
 
 	serv_port, _ := strconv.Atoi(result["ReservePort"])

--- a/hotelReservation/config.json
+++ b/hotelReservation/config.json
@@ -18,5 +18,5 @@
   "SearchPort": "8082",
   "UserPort": "8086",
   "UserMongoAddress": "mongodb-user:27017",
-  "KnativeDomainName":  "default.10.108.189.25.sslip.io:80"
+  "KnativeDomainName": ""
 }

--- a/hotelReservation/services/profile/server.go
+++ b/hotelReservation/services/profile/server.go
@@ -117,48 +117,50 @@ func (s *Server) GetProfiles(ctx context.Context, req *pb.Request) (*pb.Result, 
 	hotels := make([]*pb.Hotel, 0)
 
 	// one hotel should only have one profile
+	hotelIds := make([]string, 0)
+	profileMap := make(map[string]struct{})
+	for _, hotelId := range req.HotelIds {
+		hotelIds = append(hotelIds, hotelId)
+		profileMap[hotelId] = struct{}{}
+	}
+	resMap, err := s.MemcClient.GetMulti(hotelIds)
+	if err != nil && err != memcache.ErrCacheMiss {
+		log.Panic().Msgf("Tried to get hotelIds [%v], but got memmcached error = %s", hotelIds, err)
+	} else {
+		for hotelId, item := range resMap {
+			profileStr := string(item.Value)
+			log.Trace().Msgf("memc hit with %v", profileStr)
 
-	for _, i := range req.HotelIds {
-		// first check memcached
-		item, err := s.MemcClient.Get(i)
-		if err == nil {
-			// memcached hit
-			profile_str := string(item.Value)
-			log.Trace().Msgf("memc hit with %v", profile_str)
+			hotelProf := new(pb.Hotel)
+			json.Unmarshal(item.Value, hotelProf)
+			hotels = append(hotels, hotelProf)
+			delete(profileMap, hotelId)
+		}
 
-			hotel_prof := new(pb.Hotel)
-			json.Unmarshal(item.Value, hotel_prof)
-			hotels = append(hotels, hotel_prof)
+		for hotelId := range profileMap {
+			func(hotelId string) {
+				session := s.MongoSession.Copy()
+				defer session.Close()
+				c := session.DB("profile-db").C("hotels")
 
-		} else if err == memcache.ErrCacheMiss {
-			// memcached miss, set up mongo connection
-			session := s.MongoSession.Copy()
-			defer session.Close()
-			c := session.DB("profile-db").C("hotels")
+				hotelProf := new(pb.Hotel)
+				err := c.Find(bson.M{"id": hotelId}).One(&hotelProf)
 
-			hotel_prof := new(pb.Hotel)
-			err := c.Find(bson.M{"id": i}).One(&hotel_prof)
+				if err != nil {
+					log.Error().Msgf("Failed get hotels data: ", err)
+				}
 
-			if err != nil {
-				log.Error().Msgf("Failed get hotels data: ", err)
-			}
+				hotels = append(hotels, hotelProf)
 
-			// for _, h := range hotels {
-			// 	res.Hotels = append(res.Hotels, h)
-			// }
-			hotels = append(hotels, hotel_prof)
+				profJson, err := json.Marshal(hotelProf)
+				if err != nil {
+					log.Error().Msgf("Failed to marshal hotel [id: %v] with err:", hotelProf.Id, err)
+				}
+				memcStr := string(profJson)
 
-			prof_json, err := json.Marshal(hotel_prof)
-			if err != nil {
-				log.Error().Msgf("Failed to marshal hotel [id: %v] with err:", hotel_prof.Id, err)
-			}
-			memc_str := string(prof_json)
-
-			// write to memcached
-			s.MemcClient.Set(&memcache.Item{Key: i, Value: []byte(memc_str)})
-
-		} else {
-			log.Panic().Msgf("Tried to get hotelId [%v], but got memmcached error = %s", i, err)
+				// write to memcached
+				s.MemcClient.Set(&memcache.Item{Key: hotelId, Value: []byte(memcStr)})
+			}(hotelId)
 		}
 	}
 

--- a/hotelReservation/services/reservation/server.go
+++ b/hotelReservation/services/reservation/server.go
@@ -24,7 +24,7 @@ import (
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/rs/zerolog/log"
 
-	// "strings"
+	"strings"
 	"strconv"
 )
 
@@ -240,86 +240,135 @@ func (s *Server) CheckAvailability(ctx context.Context, req *pb.Request) (*pb.Re
 	session := s.MongoSession.Copy()
 	defer session.Close()
 
-	c := session.DB("reservation-db").C("reservation")
 	c1 := session.DB("reservation-db").C("number")
 
+	hotelMemKeys := []string{}
+	keysMap := make(map[string]struct{})
+	resMap := make(map[string]bool)
+	// cache capacity since it will not change
+	for _, hotelId := range req.HotelId {
+		hotelMemKeys = append(hotelMemKeys, hotelId+"_cap")
+		resMap[hotelId] = true
+		keysMap[hotelId+"_cap"] = struct{}{}
+	}
+	cacheMemRes, err := s.MemcClient.GetMulti(hotelMemKeys)
+	misKeys := []string{}
+	// gather cache miss key to query in mongodb
+	if err == memcache.ErrCacheMiss {
+		for key := range keysMap {
+			if _, ok := cacheMemRes[key]; !ok {
+				misKeys = append(misKeys, key)
+			}
+		}
+	} else if err != nil {
+		log.Panic().Msgf("Tried to get memc_cap_key [%v], but got memmcached error = %s", hotelMemKeys, err)
+	}
+	// store whole capacity result in cacheCap
+	cacheCap := make(map[string]int)
+	for k, v := range cacheMemRes {
+		hotelCap, _ := strconv.Atoi(string(v.Value))
+		cacheCap[k] = hotelCap
+	}
+	if len(misKeys) > 0 {
+		queryMissKeys := []string{}
+		for _, k := range misKeys {
+			queryMissKeys = append(queryMissKeys, strings.Split(k, "_")[0])
+		}
+		nums := []number{}
+		if err := c1.Find(bson.M{"hotelId": bson.M{"$in": queryMissKeys}}).All(&nums); err != nil {
+			log.Panic().Msgf("Tried to find hotelId [%v], but got error", misKeys, err.Error())
+		}
+		for _, num := range nums {
+			cacheCap[num.HotelId] = num.Number
+			// we don't care set successfully or not
+			s.MemcClient.Set(&memcache.Item{Key: num.HotelId + "_cap", Value: []byte(strconv.Itoa(num.Number))})
+		}
+	}
+
+	reqCommand := []string{}
+	queryMap := make(map[string]map[string]string)
 	for _, hotelId := range req.HotelId {
 		log.Trace().Msgf("reservation check hotel %s", hotelId)
 		inDate, _ := time.Parse(
 			time.RFC3339,
 			req.InDate+"T12:00:00+00:00")
-
 		outDate, _ := time.Parse(
 			time.RFC3339,
 			req.OutDate+"T12:00:00+00:00")
-
-		indate := inDate.String()[0:10]
-
 		for inDate.Before(outDate) {
-			// check reservations
-			count := 0
+			indate := inDate.String()[:10]
 			inDate = inDate.AddDate(0, 0, 1)
-			log.Trace().Msgf("reservation check date %s", inDate.String()[0:10])
-			outdate := inDate.String()[0:10]
-
-			// first check memc
-			memc_key := hotelId + "_" + inDate.String()[0:10] + "_" + outdate
-			item, err := s.MemcClient.Get(memc_key)
-
-			if err == nil {
-				// memcached hit
-				count, _ = strconv.Atoi(string(item.Value))
-				log.Trace().Msgf("memcached hit %s = %d", memc_key, count)
-			} else if err == memcache.ErrCacheMiss {
-				// memcached miss
-				reserve := make([]reservation, 0)
-				err := c.Find(&bson.M{"hotelId": hotelId, "inDate": indate, "outDate": outdate}).All(&reserve)
-				if err != nil {
-					log.Panic().Msgf("Tried to find hotelId [%v] from date [%v] to date [%v], but got error", hotelId, indate, outdate, err.Error())
-				}
-				for _, r := range reserve {
-					log.Trace().Msgf("reservation check reservation number = %d", hotelId)
-					count += r.Number
-				}
-
-				// update memcached
-				s.MemcClient.Set(&memcache.Item{Key: memc_key, Value: []byte(strconv.Itoa(count))})
-			} else {
-				log.Panic().Msgf("Tried to get memc_key [%v], but got memmcached error = %s", memc_key, err)
-
+			outDate := inDate.String()[:10]
+			memcKey := hotelId + "_" + outDate + "_" + outDate
+			reqCommand = append(reqCommand, memcKey)
+			queryMap[memcKey] = map[string]string{
+				"hotelId":   hotelId,
+				"startDate": indate,
+				"endDate":   outDate,
 			}
+		}
+	}
 
-			// check capacity
-			// check memc capacity
-			memc_cap_key := hotelId + "_cap"
-			item, err = s.MemcClient.Get(memc_cap_key)
-			hotel_cap := 0
-
-			if err == nil {
-				// memcached hit
-				hotel_cap, _ = strconv.Atoi(string(item.Value))
-				log.Trace().Msgf("memcached hit %s = %d", memc_cap_key, hotel_cap)
-			} else if err == memcache.ErrCacheMiss {
-				var num number
-				err = c1.Find(&bson.M{"hotelId": hotelId}).One(&num)
-				if err != nil {
-					log.Panic().Msgf("Tried to find hotelId [%v], but got error", hotelId, err.Error())
-				}
-				hotel_cap = int(num.Number)
-				// update memcached
-				s.MemcClient.Set(&memcache.Item{Key: memc_cap_key, Value: []byte(strconv.Itoa(hotel_cap))})
-			} else {
-				log.Panic().Msgf("Tried to get memc_key [%v], but got memmcached error = %s", memc_cap_key, err)
+	type taskRes struct {
+		hotelId  string
+		checkRes bool
+	}
+	// check capacity in memcached and mongodb
+	if itemsMap, err := s.MemcClient.GetMulti(reqCommand); err != nil && err != memcache.ErrCacheMiss {
+		log.Panic().Msgf("Tried to get memc_key [%v], but got memmcached error = %s", reqCommand, err)
+	} else {
+		// go through reservation count from memcached
+		for k, v := range itemsMap {
+			id := strings.Split(k, "_")[0]
+			val, _ := strconv.Atoi(string(v.Value))
+			var res bool
+			if val+int(req.RoomNumber) <= cacheCap[id] {
+				res = true
 			}
-
-			if count+int(req.RoomNumber) > hotel_cap {
-				break
+			if !res {
+				resMap[id] = false
 			}
-			indate = outdate
-
-			if inDate.Equal(outDate) {
-				res.HotelId = append(res.HotelId, hotelId)
+		}
+		// use miss reservation to get data from mongo
+		// rever string to indata and outdate
+		if err == memcache.ErrCacheMiss {
+			for k := range itemsMap {
+				delete(queryMap, k)
 			}
+			for command := range queryMap {
+				func(comm string) {
+					reserve := []reservation{}
+					tmpSess := s.MongoSession.Copy()
+					queryItem := queryMap[comm]
+					c := tmpSess.DB("reservation-db").C("reservation")
+					err := c.Find(&bson.M{"hotelId": queryItem["hotelId"], "inDate": queryItem["startDate"], "outDate": queryItem["endDate"]}).All(&reserve)
+					defer tmpSess.Close()
+					if err != nil {
+						log.Panic().Msgf("Tried to find hotelId [%v] from date [%v] to date [%v], but got error",
+							queryItem["hotelId"], queryItem["startDate"], queryItem["endDate"], err.Error())
+					}
+					var count int
+					for _, r := range reserve {
+						log.Trace().Msgf("reservation check reservation number = %d", queryItem["hotelId"])
+						count += r.Number
+					}
+					// update memcached
+					s.MemcClient.Set(&memcache.Item{Key: comm, Value: []byte(strconv.Itoa(count))})
+					var res bool
+					if count+int(req.RoomNumber) <= cacheCap[queryItem["hotelId"]] {
+						res = true
+					}
+					if !res {
+						resMap[queryItem["hotelId"]] = false
+					}
+				}(command)
+			}
+		}
+	}
+
+	for k, v := range resMap {
+		if v {
+			res.HotelId = append(res.HotelId, k)
 		}
 	}
 


### PR DESCRIPTION
This PR contains the following throughput enhancement for hotelReservation:
- Use getMulti() API to avoid calling get() multiple times when reading from memcached
- Use goroutine when writing to memcached for better concurrency
- Add child span for memcached/mongo access for jaeger trace
- Support multiple memcached instances
- Fix off-the-shelf docker-compose environment not running issue due to Knative setting