### PR TITLE
Only include the necessary files to compile the Docker image

### DIFF
--- a/mediaMicroservices/.dockerignore
+++ b/mediaMicroservices/.dockerignore
@@ -1,3 +1,8 @@
-cmake-build-debug-remote-host/*
-cmake-build-debug-remote/*
-wrk2/*
+*
+!/src/
+!/CMakeLists.txt
+!/cmake/
+!/datasets/
+!/gen-cpp/
+!/scripts/
+!/third_party/


### PR DESCRIPTION
This can shorten the time to compile the Docker image