### PR TITLE
Fix Missing Requests from Logs

### DIFF
--- a/wrk2/src/wrk.c
+++ b/wrk2/src/wrk.c
@@ -272,7 +272,7 @@ int main(int argc, char **argv) {
                 FILE* ff = fopen(filename, "w");
                 uint64_t nnum = MAXL;
                 if ((t->complete) < nnum) nnum = t->complete;
-                for (uint64_t j=1; j < nnum; ++j)
+                for (uint64_t j=1; j <= nnum; ++j)
                     fprintf(ff, "%" PRIu64 "\n", raw_latency[i][j]);
                 fclose(ff);
             }


### PR DESCRIPTION
The current implementation omits the last index of the recorded completed requests for a thread. This causes the total number of requests written to the log files to be short by one request per thread. The number of requests missing from the log is equivalent to the number of threads used.

This change corrects the bug and allows for all the completed requests to be logged accurately to match the total number of completed requests.