### PR TITLE
Add the config/ folder to .dockerignore

### DIFF
--- a/mediaMicroservices/.dockerignore
+++ b/mediaMicroservices/.dockerignore
@@ -6,3 +6,4 @@
 !/gen-cpp/
 !/scripts/
 !/third_party/
+!/config/


### PR DESCRIPTION
The config/ folder is necessary for the rebuilt images of the Media Microservices application to work.