### PR TITLE
fix: correct indenting of restartPolicy field

### DIFF
--- a/hotelReservation/openshift/hr-client.yaml
+++ b/hotelReservation/openshift/hr-client.yaml
@@ -19,8 +19,6 @@ spec:
         death-star-project: hotel-res
         app: hr-client
       name: hr-client
-#      annotations:
-#        sidecar.istio.io/inject: "true"
     spec:
       containers:
       - name: hr-client
@@ -33,5 +31,5 @@ spec:
             luarocks install luasocket &&
             sleep 365d
         imagePullPolicy: Always
-        restartPolicy: Always
+      restartPolicy: Always
 


### PR DESCRIPTION
This PR fixes the indenting of the `restartPolicy` field of the hotel reservation client. Without this fix, the deployment cannot be applied to a cluster.