### PR TITLE
fix: remove memcached deployment command

### DIFF
--- a/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentMemcached.tpl
+++ b/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentMemcached.tpl
@@ -39,10 +39,6 @@ spec:
             value: {{ $.Values.global.memcached.environments.cacheSize | quote }}
           - name: MEMCACHED_THREADS
             value: {{ $.Values.global.memcached.environments.threads | quote }}
-        command:
-          - "memcached"
-          - "-c"
-          - "65536"
         {{- if .args}}
         args:
         {{- range $arg := .args}}

--- a/hotelReservation/openshift/memcached-profile-deployment.yaml
+++ b/hotelReservation/openshift/memcached-profile-deployment.yaml
@@ -30,7 +30,6 @@ spec:
           value: "2"
         image: memcached
         name: hotel-reserv-profile-mmc
-        command: ["memcached", "-c", "65536"]
         ports:
         - containerPort: 11211
         resources: {}

--- a/hotelReservation/openshift/memcached-rate-deployment.yaml
+++ b/hotelReservation/openshift/memcached-rate-deployment.yaml
@@ -30,7 +30,6 @@ spec:
           value: "2"
         image: memcached
         name: hotel-reserv-rate-mmc
-        command: ["memcached", "-c", "65536"]
         ports:
         - containerPort: 11211
         resources: {}

--- a/hotelReservation/openshift/memcached-reserve-deployment.yaml
+++ b/hotelReservation/openshift/memcached-reserve-deployment.yaml
@@ -30,7 +30,6 @@ spec:
           value: "2"
         image: memcached
         name: hotel-reserv-reservation-mmc
-        command: ["memcached", "-c", "65536"]
         ports:
         - containerPort: 11211
         resources: {}


### PR DESCRIPTION
This PR removes the command for all `memcached` deployments. With the current command, it fails to run on clusters because the number specified is too high.