### PR TITLE
feature: wrk2 client docker

### DIFF
--- a/.github/workflows/wrk2-client-push.yaml
+++ b/.github/workflows/wrk2-client-push.yaml
@@ -1,0 +1,58 @@
+name: Push wrk2 client
+concurrency: ci-wrk2-client
+
+on:
+  push: 
+    branches: [ master ]
+    paths: 
+      - 'wrk2/**'
+
+env:
+  IMAGE_BASE_NAME: 'deathstarbench/wrk2-client'
+  REPO_PATH: 'wrk2'
+  TAG_PREFIX: 'wrk2'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: master
+        fetch-depth: 0 
+    - name: Login to ACR
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_REGISTRY_LOGIN }}
+        password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+    - name: Build docker image
+      run: docker build -f "${{ env.REPO_PATH }}/Dockerfile" -t ${{ env.IMAGE_BASE_NAME }} ${{ env.REPO_PATH }}
+    - name: Calculate new version
+      id: new-version
+      uses: codacy/git-version@2.4.0
+      with:
+        prefix: "${{ env.TAG_PREFIX }}-"
+        log-paths: "${{ env.REPO_PATH }}/"
+      if: github.ref == 'refs/heads/master'
+    - name: Create tag
+      uses: actions/github-script@v5
+      with:
+        script: |
+          github.rest.git.createRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: 'refs/tags/${{ steps.new-version.outputs.VERSION }}',
+            sha: context.sha
+          })
+    - name: Retrieve version number
+      run: TEMP=${{ steps.new-version.outputs.VERSION }} && echo VERSION_NUMBER=${TEMP#*-} >> $GITHUB_ENV
+    - name: Create image full name
+      run: echo "IMAGE_ID=${{ env.IMAGE_BASE_NAME }}:${{ env.VERSION_NUMBER }}" >> $GITHUB_ENV
+    - name: Tag image
+      run: docker tag ${{ env.IMAGE_BASE_NAME }} ${{ env.IMAGE_ID }}
+    - name: Push docker image
+      run: docker push ${{ env.IMAGE_ID }}
+    - name: Tag image as latest
+      run: docker tag ${{ env.IMAGE_BASE_NAME }} ${{ env.IMAGE_BASE_NAME }}:latest
+    - name: Push latest
+      run: docker push ${{ env.IMAGE_BASE_NAME }}:latest

--- a/hotelReservation/openshift/hr-client.yaml
+++ b/hotelReservation/openshift/hr-client.yaml
@@ -25,6 +25,10 @@ spec:
       containers:
       - name: hr-client
         image: deathstarbench/wrk2-client
+        command:  ["/bin/sh"]
+        args:
+          - -c
+          - sleep 365d
         imagePullPolicy: Always
         restartPolicy: Always
 

--- a/hotelReservation/openshift/hr-client.yaml
+++ b/hotelReservation/openshift/hr-client.yaml
@@ -24,14 +24,7 @@ spec:
     spec:
       containers:
       - name: hr-client
-        image: ubuntu
-        command:  ["/bin/sh", "-c"]
-        args:
-          - apt-get -y update &&
-            apt-get -y upgrade &&
-            apt-get -y install dnsutils git vim python3 python3-aiohttp libssl-dev libz-dev luarocks iputils-ping lynx build-essential gcc bash curl &&
-            luarocks install luasocket &&
-            sleep 365d
+        image: deathstarbench/wrk2-client
         imagePullPolicy: Always
         restartPolicy: Always
 

--- a/mediaMicroservices/openshift/mms-client.yaml
+++ b/mediaMicroservices/openshift/mms-client.yaml
@@ -25,6 +25,10 @@ spec:
       containers:
       - name: mms-client
         image: deathstarbench/wrk2-client
+        command:  ["/bin/sh"]
+        args:
+          - -c
+          - sleep 365d
 #        volumeMounts:
 #        - mountPath: /root/DeathStarBench
 #          name: deathstarbench

--- a/mediaMicroservices/openshift/mms-client.yaml
+++ b/mediaMicroservices/openshift/mms-client.yaml
@@ -24,14 +24,7 @@ spec:
     spec:
       containers:
       - name: mms-client
-        image: ubuntu
-        command:  ["/bin/sh", "-c"]
-        args:
-          - apt-get -y update &&
-            apt-get -y upgrade &&
-            apt-get -y install git dnsutils vim python3 python3-aiohttp libssl-dev libz-dev luarocks iputils-ping lynx build-essential gcc bash curl &&
-            luarocks install luasocket &&
-            sleep 365d
+        image: deathstarbench/wrk2-client
 #        volumeMounts:
 #        - mountPath: /root/DeathStarBench
 #          name: deathstarbench

--- a/socialNetwork/openshift/ubuntu-client.yaml
+++ b/socialNetwork/openshift/ubuntu-client.yaml
@@ -22,13 +22,6 @@ spec:
     spec:
       containers:
       - name: ubuntu-client
-        image: ubuntu
-        command:  ["/bin/sh", "-c"]
-        args:
-          - apt-get -y update &&
-            apt-get -y upgrade &&
-            apt-get -y install dnsutils git vim python3 python3-aiohttp libssl-dev libz-dev luarocks iputils-ping lynx build-essential gcc bash curl &&
-            luarocks install luasocket &&
-            sleep 365d
+        image: deathstarbench/wrk2-client
         imagePullPolicy: Always
       restartPolicy: Always

--- a/socialNetwork/openshift/ubuntu-client.yaml
+++ b/socialNetwork/openshift/ubuntu-client.yaml
@@ -23,5 +23,9 @@ spec:
       containers:
       - name: ubuntu-client
         image: deathstarbench/wrk2-client
+        command:  ["/bin/sh"]
+        args:
+          - -c
+          - sleep 365d
         imagePullPolicy: Always
       restartPolicy: Always

--- a/wrk2/Dockerfile
+++ b/wrk2/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:22.04 as builder
+
+WORKDIR /workspace
+
+ARG LUA_JIT_VERSION=2.1
+
+RUN apt-get update -y && \
+    apt-get install -y git libssl-dev libz-dev luarocks make && \
+    wget https://github.com/LuaJIT/LuaJIT/archive/refs/tags/v${LUA_JIT_VERSION}.ROLLING.tar.gz && \
+    tar -zxf v${LUA_JIT_VERSION}.ROLLING.tar.gz
+
+RUN mkdir -p /build/deps/luajit && \
+    cp -r LuaJIT-${LUA_JIT_VERSION}.ROLLING/* /build/deps/luajit
+
+WORKDIR /build
+
+COPY src/ src/
+COPY Makefile Makefile
+
+RUN make clean && make
+
+FROM ubuntu:22.04
+
+COPY --from=builder /build/wrk /usr/local/bin/wrk
+
+RUN apt-get update -y && \
+    apt-get install -y gcc luarocks && \
+    luarocks install luasocket
+
+CMD ["/bin/bash"]

--- a/wrk2/Dockerfile
+++ b/wrk2/Dockerfile
@@ -6,10 +6,11 @@ ARG LUA_JIT_VERSION=2.1
 
 RUN apt-get update -y && \
     apt-get install -y git libssl-dev libz-dev luarocks make && \
-    wget https://github.com/LuaJIT/LuaJIT/archive/refs/tags/v${LUA_JIT_VERSION}.ROLLING.tar.gz && \
-    tar -zxf v${LUA_JIT_VERSION}.ROLLING.tar.gz
+    luarocks install luasocket
 
-RUN mkdir -p /build/deps/luajit && \
+RUN wget https://github.com/LuaJIT/LuaJIT/archive/refs/tags/v${LUA_JIT_VERSION}.ROLLING.tar.gz && \
+    tar -zxf v${LUA_JIT_VERSION}.ROLLING.tar.gz && \
+    mkdir -p /build/deps/luajit && \
     cp -r LuaJIT-${LUA_JIT_VERSION}.ROLLING/* /build/deps/luajit
 
 WORKDIR /build
@@ -22,9 +23,8 @@ RUN make clean && make
 FROM ubuntu:22.04
 
 COPY --from=builder /build/wrk /usr/local/bin/wrk
-
-RUN apt-get update -y && \
-    apt-get install -y gcc luarocks && \
-    luarocks install luasocket
+COPY --from=builder /usr/local/lib/lua /usr/local/lib/lua
+COPY --from=builder /usr/local/lib/luarocks /usr/local/lib/luarocks
+COPY --from=builder /usr/local/share/lua /usr/local/share/lua
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
This PR adds a Dockerfile to build the wrk2 client used for workload generation across the various projects. By using an image, this can help save some time in waiting for the wrk2 compilation to complete before copying over the specific wrk files for a given applications.

Note for reviewer: In order to compile wrk2, I had to use the 2.1 runtime instead of the 2.0. This is because while I was compiling the client with 2.0, I kept on hitting an `out of memory` error while attempting to build the image.