### PR TITLE
feature: allow jaeger to be configured from environment variables

### DIFF
--- a/hotelReservation/tracing/tracer.go
+++ b/hotelReservation/tracing/tracer.go
@@ -23,8 +23,10 @@ func Init(serviceName, host string) (opentracing.Tracer, error) {
 			ratio = 1.0
 		}
 	}
+	
 	log.Info().Msgf("Jaeger client: adjusted sample ratio %f", ratio)
-	cfg := config.Configuration{
+	tempCfg := &config.Configuration{
+		ServiceName: serviceName,
 		Sampler: &config.SamplerConfig{
 			Type:  "probabilistic",
 			Param: ratio,
@@ -36,7 +38,13 @@ func Init(serviceName, host string) (opentracing.Tracer, error) {
 		},
 	}
 
-	tracer, _, err := cfg.New(serviceName)
+	log.Info().Msg("Overriding Jaeger config with env variables")
+	cfg, err := tempCfg.FromEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	tracer, _, err := cfg.NewTracer(serviceName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR allows Jaeger to be configured via environment variables. This will allow the user to overwrite or use more functionality of Jaeger without needing to change the configuration in code.