### PR TITLE
multiple update on helm template

### DIFF
--- a/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentMemcached.tpl
+++ b/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentMemcached.tpl
@@ -34,11 +34,19 @@ spec:
         {{- range $cport := .ports }}
         - containerPort: {{ $cport.containerPort -}}
         {{ end }}
+        {{- if hasKey . "environments" }}
         env:
-          - name: MEMCACHED_CACHE_SIZE
-            value: {{ $.Values.global.memcached.environments.cacheSize | quote }}
-          - name: MEMCACHED_THREADS
-            value: {{ $.Values.global.memcached.environments.threads | quote }}
+          {{- range $variable, $value := .environments }}
+          - name: {{ $variable }}
+            value: {{ $value | quote }}
+          {{- end }}
+        {{- else if hasKey $.Values.global.memcached "environments" }}
+        env:
+          {{- range $variable, $value := $.Values.global.memcached.environments }}
+          - name: {{ $variable }}
+            value: {{ $value | quote }}
+          {{- end }}
+        {{- end }}
         {{- if .args}}
         args:
         {{- range $arg := .args}}

--- a/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentMongoDB.tpl
+++ b/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentMongoDB.tpl
@@ -46,11 +46,9 @@ spec:
         resources:
           {{ tpl $.Values.global.resources $ | nindent 10 | trim }}
         {{- end }}
-	{{- if $.Values.global.mongodb.persistentVolume.hostPath.enabled }}
         volumeMounts:
         - mountPath: /data/db
           name: {{ $.Values.name }}-{{ include "hotel-reservation.fullname" $ }}-path
-        {{- end }}
       {{- end }}
       volumes:
       - name: {{ .Values.name }}-{{ include "hotel-reservation.fullname" . }}-path

--- a/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentServices.tpl
+++ b/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentServices.tpl
@@ -29,17 +29,19 @@ spec:
         {{- range $cport := .ports }}
         - containerPort: {{ $cport.containerPort -}}
         {{ end }}
+        {{- if hasKey . "environments" }}
         env:
-          - name: TLS
-            value: {{ $.Values.global.services.environments.tls | quote }}
-          - name: LOG_LEVEL
-            value: {{ $.Values.global.services.environments.logLevel | quote }}
-          - name: JAEGER_SAMPLE_RATIO
-            value: {{ $.Values.global.services.environments.jaegerSampleRatio | quote }}
-          - name: MEMC_TIMEOUT
-            value: {{ $.Values.global.services.environments.memcachedTimeout | quote }}
-          - name: GC
-            value: {{ $.Values.global.services.environments.gcPercent | quote }}
+          {{- range $variable, $value := .environments }}
+          - name: {{ $variable }}
+            value: {{ $value | quote }}
+          {{- end }}
+        {{- else if hasKey $.Values.global.services "environments" }}
+        env:
+          {{- range $variable, $value := $.Values.global.services.environments }}
+          - name: {{ $variable }}
+            value: {{ $value | quote }}
+          {{- end }}
+        {{- end }}
         {{- if .command}}
         command:
         - {{ .command }}

--- a/hotelReservation/helm-chart/hotelreservation/templates/_basePersistentVolume.tpl
+++ b/hotelReservation/helm-chart/hotelreservation/templates/_basePersistentVolume.tpl
@@ -1,4 +1,5 @@
 {{- define "hotelreservation.templates.basePersistentVolume" }}
+{{- if .Values.global.mongodb.persistentVolume.enabled }}
 {{- if .Values.global.mongodb.persistentVolume.hostPath.enabled }}
 apiVersion: v1
 kind: PersistentVolume
@@ -15,5 +16,6 @@ spec:
   hostPath:
     path: {{ .Values.global.mongodb.persistentVolume.hostPath.path }}/{{ .Values.name }}-pv
     type: DirectoryOrCreate
+{{- end }}
 {{- end }}
 {{- end }}

--- a/hotelReservation/helm-chart/hotelreservation/values.yaml
+++ b/hotelReservation/helm-chart/hotelreservation/values.yaml
@@ -15,19 +15,19 @@ global:
       #  - 0: Disable
       #  - 1: Enabled, using default cipher suite based on golang runtime
       #  - TLS_XXX: Enabled, using the specified Cipher suite, see tls/options.go#L22
-      tls: 0
-      logLevel: "INFO"
-      jaegerSampleRatio: "0.01"
-      memcachedTimeout: "2"
-      gcPercent: "100"
+      TLS: 0
+      LOG_LEVEL: "INFO"
+      JAEGER_SAMPLE_RATIO: "0.01"
+      MEMC_TIMEOUT: "2"
+      GC: "100"
   affinity: {}
   tolerations: []
   nodeSelector: {}
   memcached:
     HACount: 1
     environments:
-      cacheSize: "128"
-      threads: "2"
+      MEMCACHED_CACHE_SIZE: "128"
+      MEMCACHED_THREADS: "2"
   mongodb:
     enbaled: false
     persistentVolume:               # use hostPath or pvprovisioner

--- a/hotelReservation/helm-chart/hotelreservation/values.yaml
+++ b/hotelReservation/helm-chart/hotelreservation/values.yaml
@@ -29,11 +29,11 @@ global:
       MEMCACHED_CACHE_SIZE: "128"
       MEMCACHED_THREADS: "2"
   mongodb:
-    enbaled: false
     persistentVolume:               # use hostPath or pvprovisioner
+      enabled: false
       size: "1Gi"
       hostPath:
-        enabled: true
+        enabled: false
         path: /tmp
       pvprovisioner:
         enabled: false


### PR DESCRIPTION
1. Update the helm template so that environment variable can be set directly instead of redundant work in template file, and also easy for use of new environment variables.
2. Update the helm template so that two PVs are supported, one is through hostPath and the other is by dynamic volume provisioning.