### PR TITLE
Change: jaeger sample rate (helm) from 0.01 to 0.1; same as docker one

### DIFF
--- a/socialNetwork/helm-chart/socialnetwork/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/values.yaml
@@ -37,7 +37,7 @@ global:
     queueSize: 1000000
     bufferFlushInterval: 10
     samplerType: probabilistic
-    samplerParam: 0.01
+    samplerParam: 0.1
     disabled: false
     logSpans: false
 


### PR DESCRIPTION
Background
I was deploying social network with docker and helm, and find out the number of traces has a large difference. Was thinking to solve it with different approach listed in [this issue](https://github.com/delimitrou/DeathStarBench/issues/291). But find out it is related to the sampling rate. I would like to change it so that the other people may not be confused.

Change
samplerParam: 0.01 -> 0.1