### PR TITLE
fix: remove argument from NewTracer

### DIFF
--- a/hotelReservation/tracing/tracer.go
+++ b/hotelReservation/tracing/tracer.go
@@ -44,7 +44,7 @@ func Init(serviceName, host string) (opentracing.Tracer, error) {
 		return nil, err
 	}
 
-	tracer, _, err := cfg.NewTracer(serviceName)
+	tracer, _, err := cfg.NewTracer()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is a fix PR for #290. The previous PR contained an improper argument for the `NewTracer` method. This PR correctly calls the method.