### PR TITLE
hotelReservation: add label for backend services and support annotations

### DIFF
--- a/hotelReservation/helm-chart/hotelreservation/charts/profile/values.yaml
+++ b/hotelReservation/helm-chart/hotelreservation/charts/profile/values.yaml
@@ -10,9 +10,6 @@ container:
   name: hotel-reserv-profile
   ports:
   - containerPort: 8081
-  environments:
-    logLevel: INFO
-    jaegerSampleRatio: 1
 
 configMaps:
   - name: service-config.json

--- a/hotelReservation/helm-chart/hotelreservation/charts/rate/values.yaml
+++ b/hotelReservation/helm-chart/hotelreservation/charts/rate/values.yaml
@@ -10,9 +10,6 @@ container:
   name: hotel-reserv-rate
   ports:
   - containerPort: 8084
-  environments:
-    logLevel: INFO
-    jaegerSampleRatio: 1
 
 configMaps:
   - name: service-config.json

--- a/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentMemcached.tpl
+++ b/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentMemcached.tpl
@@ -9,6 +9,7 @@ kind: Deployment
 metadata:
   labels:
     {{- include "hotel-reservation.labels" . | nindent 4 }}
+    {{- include "hotel-reservation.backendLabels" . | nindent 4 }}
     service: {{ .Values.name }}-{{ $rangeItem }}-{{ include "hotel-reservation.fullname" . }}
   name: {{ .Values.name }}-{{ $rangeItem }}-{{ include "hotel-reservation.fullname" . }}
 spec:
@@ -16,12 +17,14 @@ spec:
   selector:
     matchLabels:
       {{- include "hotel-reservation.selectorLabels" . | nindent 6 }}
+      {{- include "hotel-reservation.backendLabels" . | nindent 6 }}
       service: {{ .Values.name }}-{{ $rangeItem }}-{{ include "hotel-reservation.fullname" . }}
       app: {{ .Values.name }}-{{ $rangeItem }}-{{ include "hotel-reservation.fullname" . }}
   template:
     metadata:
       labels:
         {{- include "hotel-reservation.labels" . | nindent 8 }}
+        {{- include "hotel-reservation.backendLabels" . | nindent 8 }}
         service: {{ .Values.name }}-{{ $rangeItem }}-{{ include "hotel-reservation.fullname" . }}
         app: {{ .Values.name }}-{{ $rangeItem }}-{{ include "hotel-reservation.fullname" . }}
     spec:
@@ -50,7 +53,7 @@ spec:
         {{- if .args}}
         args:
         {{- range $arg := .args}}
-        - {{ $arg }}
+        - {{ $arg | quote }}
         {{- end -}}
         {{- end }}
         {{- if .resources }}
@@ -64,9 +67,9 @@ spec:
       {{- if hasKey .Values "topologySpreadConstraints" }}
       topologySpreadConstraints:
         {{ tpl .Values.topologySpreadConstraints . | nindent 6 | trim }}
-      {{- else if hasKey $.Values.global  "topologySpreadConstraints" }}
+      {{- else if hasKey $.Values.global.memcached "topologySpreadConstraints" }}
       topologySpreadConstraints:
-        {{ tpl $.Values.global.topologySpreadConstraints . | nindent 6 | trim }}
+        {{ tpl $.Values.global.memcached.topologySpreadConstraints . | nindent 6 | trim }}
       {{- end }}
       hostname: {{ .Values.name }}-{{ include "hotel-reservation.fullname" . }}
       restartPolicy: {{ .Values.restartPolicy | default .Values.global.restartPolicy}}

--- a/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentMemcached.tpl
+++ b/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentMemcached.tpl
@@ -27,6 +27,13 @@ spec:
         {{- include "hotel-reservation.backendLabels" . | nindent 8 }}
         service: {{ .Values.name }}-{{ $rangeItem }}-{{ include "hotel-reservation.fullname" . }}
         app: {{ .Values.name }}-{{ $rangeItem }}-{{ include "hotel-reservation.fullname" . }}
+      {{- if hasKey $.Values "annotations" }}
+      annotations:
+        {{ tpl $.Values.annotations . | nindent 8 | trim }}
+      {{- else if hasKey $.Values.global "annotations" }}
+      annotations:
+        {{ tpl $.Values.global.annotations . | nindent 8 | trim }}
+      {{- end }}
     spec:
       containers:
       {{- with .Values.container }}

--- a/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentMongoDB.tpl
+++ b/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentMongoDB.tpl
@@ -22,6 +22,13 @@ spec:
         {{- include "hotel-reservation.backendLabels" . | nindent 8 }}
         service: {{ .Values.name }}-{{ include "hotel-reservation.fullname" . }}
         app: {{ .Values.name }}-{{ include "hotel-reservation.fullname" . }}
+      {{- if hasKey $.Values "annotations" }}
+      annotations:
+        {{ tpl $.Values.annotations . | nindent 8 | trim }}
+      {{- else if hasKey $.Values.global "annotations" }}
+      annotations:
+        {{ tpl $.Values.global.annotations . | nindent 8 | trim }}
+      {{- end }}
     spec:
       containers:
       {{- with .Values.container }}

--- a/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentMongoDB.tpl
+++ b/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentMongoDB.tpl
@@ -4,6 +4,7 @@ kind: Deployment
 metadata:
   labels:
     {{- include "hotel-reservation.labels" . | nindent 4 }}
+    {{- include "hotel-reservation.backendLabels" . | nindent 4 }}
     service: {{ .Values.name }}-{{ include "hotel-reservation.fullname" . }}
   name: {{ .Values.name }}-{{ include "hotel-reservation.fullname" . }}
 spec:
@@ -11,12 +12,14 @@ spec:
   selector:
     matchLabels:
       {{- include "hotel-reservation.selectorLabels" . | nindent 6 }}
+      {{- include "hotel-reservation.backendLabels" . | nindent 6 }}
       service: {{ .Values.name }}-{{ include "hotel-reservation.fullname" . }}
       app: {{ .Values.name }}-{{ include "hotel-reservation.fullname" . }}
   template:
     metadata:
       labels:
         {{- include "hotel-reservation.labels" . | nindent 8 }}
+        {{- include "hotel-reservation.backendLabels" . | nindent 8 }}
         service: {{ .Values.name }}-{{ include "hotel-reservation.fullname" . }}
         app: {{ .Values.name }}-{{ include "hotel-reservation.fullname" . }}
     spec:
@@ -61,9 +64,9 @@ spec:
       {{- if hasKey .Values "topologySpreadConstraints" }}
       topologySpreadConstraints:
         {{ tpl .Values.topologySpreadConstraints . | nindent 6 | trim }}
-      {{- else if hasKey $.Values.global  "topologySpreadConstraints" }}
+      {{- else if hasKey $.Values.global.mongodb "topologySpreadConstraints" }}
       topologySpreadConstraints:
-        {{ tpl $.Values.global.topologySpreadConstraints . | nindent 6 | trim }}
+        {{ tpl $.Values.global.mongodb.topologySpreadConstraints . | nindent 6 | trim }}
       {{- end }}
       hostname: {{ .Values.name }}-{{ include "hotel-reservation.fullname" . }}
       restartPolicy: {{ .Values.restartPolicy | default .Values.global.restartPolicy}}

--- a/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentServices.tpl
+++ b/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentServices.tpl
@@ -19,6 +19,13 @@ spec:
         {{- include "hotel-reservation.labels" . | nindent 8 }}
         service: {{ .Values.name }}-{{ include "hotel-reservation.fullname" . }}
         app: {{ .Values.name }}-{{ include "hotel-reservation.fullname" . }}
+      {{- if hasKey $.Values "annotations" }}
+      annotations:
+        {{ tpl $.Values.annotations . | nindent 8 | trim }}
+      {{- else if hasKey $.Values.global "annotations" }}
+      annotations:
+        {{ tpl $.Values.global.annotations . | nindent 8 | trim }}
+      {{- end }}
     spec:
       containers:
       {{- with .Values.container }}

--- a/hotelReservation/helm-chart/hotelreservation/templates/_basePersistentVolumeClaim.tpl
+++ b/hotelReservation/helm-chart/hotelreservation/templates/_basePersistentVolumeClaim.tpl
@@ -1,17 +1,17 @@
 {{- define "hotelreservation.templates.basePersistentVolumeClaim" }}
+{{- if .Values.global.mongodb.persistentVolume.pvprovisioner.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ .Values.name }}-{{ include "hotel-reservation.fullname" . }}-pvc
 spec:
-  {{- if .Values.global.mongodb.persistentVolume.pvprovisioner.enabled }}
   {{- if .Values.global.mongodb.persistentVolume.pvprovisioner.storageClassName }}
   storageClassName: {{ .Values.global.mongodb.persistentVolume.pvprovisioner.storageClassName }}
-  {{- end }}
   {{- end }}
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
       storage: {{ .Values.global.mongodb.persistentVolume.size }}
+{{- end }}
 {{- end }}

--- a/hotelReservation/helm-chart/hotelreservation/templates/_helpers.tpl
+++ b/hotelReservation/helm-chart/hotelreservation/templates/_helpers.tpl
@@ -71,3 +71,10 @@ Usage:
   {{- end }}
   {{- join "," $addrlist | toJson }}
 {{- end }}
+
+{{/*
+Backend labels
+*/}}
+{{- define "hotel-reservation.backendLabels" -}}
+backend: {{ .Chart.Name | regexFind "[^-]*" }}
+{{- end }}


### PR DESCRIPTION
1. Add labels for memcached and mongodb so that they can be properly spread when deploying in a multiple node cluster using topologySpreadConstraints.labelSelector.matchLabels.
2. Support annotations to attach metadata to objects.