### PR TITLE
Fix wrong indent for Nginx deployment

### DIFF
--- a/socialNetwork/helm-chart/socialnetwork/templates/_baseNginxDeployment.tpl
+++ b/socialNetwork/helm-chart/socialnetwork/templates/_baseNginxDeployment.tpl
@@ -44,10 +44,10 @@ spec:
         {{- end }}
         {{- if .resources }}  
         resources:
-          {{ tpl .resources . | nindent 6 | trim }}
+          {{ tpl .resources $ | nindent 10 | trim }}
         {{- else if hasKey $.Values.global "resources" }}           
         resources:
-          {{ tpl $.Values.global.resources $ | nindent 6 | trim }}
+          {{ tpl $.Values.global.resources $ | nindent 10 | trim }}
         {{- end }}  
         {{- if $.Values.configMaps }}        
         volumeMounts: 
@@ -72,6 +72,13 @@ spec:
         command: 
         - {{ .command }}
         {{- end -}}
+        {{- if .resources }}
+        resources:
+          {{ tpl .resources $ | nindent 10 | trim }}
+        {{- else if hasKey $.Values.global "resources" }}
+        resources:
+          {{ tpl $.Values.global.resources $ | nindent 10 | trim }}
+        {{- end }}
         {{- if .env }}
         env:
         {{- range $e := .env}}


### PR DESCRIPTION
Also, add the resource attribute to the init containers in the nginx deployment.