### PR TITLE
bump: github action to node16 versions or higher

### DIFF
--- a/.github/workflows/hotelreservation-push.yaml
+++ b/.github/workflows/hotelreservation-push.yaml
@@ -16,12 +16,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: master
         fetch-depth: 0
     - name: Login to ACR
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_REGISTRY_LOGIN }}
         password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
@@ -35,7 +35,7 @@ jobs:
         log-paths: "${{ env.REPO_PATH }}/"
       if: github.ref == 'refs/heads/master'
     - name: Create tag
-      uses: actions/github-script@v5
+      uses: actions/github-script@v7
       with:
         script: |
           github.rest.git.createRef({

--- a/.github/workflows/socialnetwork-push.yaml
+++ b/.github/workflows/socialnetwork-push.yaml
@@ -16,12 +16,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: master
         fetch-depth: 0 
     - name: Login to ACR
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_REGISTRY_LOGIN }}
         password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
@@ -35,7 +35,7 @@ jobs:
         log-paths: "${{ env.REPO_PATH }}/"
       if: github.ref == 'refs/heads/master'
     - name: Create tag
-      uses: actions/github-script@v5
+      uses: actions/github-script@v7
       with:
         script: |
           github.rest.git.createRef({

--- a/.github/workflows/wrk2-client-push.yaml
+++ b/.github/workflows/wrk2-client-push.yaml
@@ -16,12 +16,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: master
         fetch-depth: 0 
     - name: Login to ACR
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_REGISTRY_LOGIN }}
         password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
@@ -35,7 +35,7 @@ jobs:
         log-paths: "${{ env.REPO_PATH }}/"
       if: github.ref == 'refs/heads/master'
     - name: Create tag
-      uses: actions/github-script@v5
+      uses: actions/github-script@v7
       with:
         script: |
           github.rest.git.createRef({


### PR DESCRIPTION
This is a `warning` which occurs in each the `build` phase for GitHub actions because the actions are using a `node12` version instead of `node16` one and are thus forced to run on a `node16`. This PR bumps the versions of these actions to get rid of the warning.