### PR TITLE
bump: use latest jaeger and memcached images

### DIFF
--- a/hotelReservation/helm-chart/hotelreservation/charts/jaeger/values.yaml
+++ b/hotelReservation/helm-chart/hotelreservation/charts/jaeger/values.yaml
@@ -25,7 +25,7 @@ ports:
 
 container:
   image: jaegertracing/all-in-one
-  imageVersion: 1.21.0
+  imageVersion: latest
   name: hotel-reserv-jaeger
   ports:
   - containerPort: 14269

--- a/hotelReservation/helm-chart/hotelreservation/charts/memcached-profile/values.yaml
+++ b/hotelReservation/helm-chart/hotelreservation/charts/memcached-profile/values.yaml
@@ -6,7 +6,7 @@ ports:
  
 container:
   image: memcached
-  imageVersion: 1.6.17
+  imageVersion: latest
   name: hotel-reserv-profile-mmc
   ports:
   - containerPort: 11211

--- a/hotelReservation/helm-chart/hotelreservation/charts/memcached-rate/values.yaml
+++ b/hotelReservation/helm-chart/hotelreservation/charts/memcached-rate/values.yaml
@@ -6,7 +6,7 @@ ports:
  
 container:
   image: memcached
-  imageVersion: 1.6.17
+  imageVersion: latest
   name: hotel-reserv-rate-mmc
   ports:
   - containerPort: 11211

--- a/hotelReservation/helm-chart/hotelreservation/charts/memcached-reserve/values.yaml
+++ b/hotelReservation/helm-chart/hotelreservation/charts/memcached-reserve/values.yaml
@@ -6,7 +6,7 @@ ports:
  
 container:
   image: memcached
-  imageVersion: 1.6.17
+  imageVersion: latest
   name: hotel-reserv-reservation-mmc
   ports:
   - containerPort: 11211


### PR DESCRIPTION
This PR updates the helm deployment method for hotel reservation to use the latest `jaeger` and `memcached` images.