### PR TITLE
docs(socialNetwork): Specify repository cloning requirement in swarm mode

### DIFF
--- a/socialNetwork/README.md
+++ b/socialNetwork/README.md
@@ -42,7 +42,9 @@ pulled from Docker Hub.
 
 #### Start docker containers on a machine cluster with `docker swarm`
 
-Before starting the containers, make sure you are on the master node of the docker swarm nodes.
+Before starting the containers, make sure:
+1. You are on the master node of the docker swarm nodes.
+2. You have cloned the DeathStarBench repository in the same location on all swarm nodes.
 
 ```bash
 docker stack deploy --compose-file=docker-compose-swarm.yml <service-name>


### PR DESCRIPTION
DeathStarBench/socialNetwork currently uses bind-mounted volumes to supply configuration to containers. Consequently, in swarm mode, the repository should be cloned in the same location on all nodes in the swarm, or services will fail silently. This PR documents this requirement.

This was likely the cause of #252.