### PR TITLE
fix: correct unimplemented server typo

### DIFF
--- a/hotelReservation/services/attractions/server.go
+++ b/hotelReservation/services/attractions/server.go
@@ -28,7 +28,7 @@ const (
 
 // Server implements the attractions service
 type Server struct {
-	pb.UnimplementedRateServer
+	pb.UnimplementedAttractionsServer
 
 	indexH *geoindex.ClusteringIndex
 	indexR *geoindex.ClusteringIndex

--- a/hotelReservation/services/review/server.go
+++ b/hotelReservation/services/review/server.go
@@ -35,7 +35,7 @@ const name = "srv-review"
 
 // Server implements the rate service
 type Server struct {
-	pb.UnimplementedRateServer
+	pb.UnimplementedReviewServer
 
 	Tracer      opentracing.Tracer
 	Port        int


### PR DESCRIPTION
Correction to #331 . The wrong `UnImplementedServer` type was used.