### PR TITLE
feat(socialNetwork): hpa for deployments & improve wrk2 instructions

### DIFF
--- a/socialNetwork/README.md
+++ b/socialNetwork/README.md
@@ -53,25 +53,41 @@ docker stack deploy --compose-file=docker-compose-swarm.yml <service-name>
 ### Register users and construct social graphs
 
 Register users and construct social graph by running
-`python3 scripts/init_social_graph.py --graph=<socfb-Reed98, ego-twitter, or soc-twitter-follows-mun>`. It will initialize a social graph from a small social network [Reed98 Facebook Networks](http://networkrepository.com/socfb-Reed98.php), a medium social network [Ego Twitter](https://snap.stanford.edu/data/ego-Twitter.html), or a large social network [TWITTER-FOLLOWS-MUN](https://networkrepository.com/soc-twitter-follows-mun.php).
+`python3 scripts/init_social_graph.py --graph=<socfb-Reed98, ego-twitter, or soc-twitter-follows-mun>`. It will initialize a social graph from a small social network [Reed98 Facebook Networks](http://networkrepository.com/socfb-Reed98.php), a medium social network [Ego Twitter](https://snap.stanford.edu/data/ego-Twitter.html), or a large social network [TWITTER-FOLLOWS-MUN](https://networkrepository.com/soc-twitter-follows-mun.php). If your setup is not local, you can specify the IP and port of the nginx through `--ip` and `--port` flags, respectively.
 
 ### Running HTTP workload generator
 
 #### Make
 
+It is necessary to build the workload generator tool. Thus, please assert that:
+1. Your repository was cloned using `--recurse-submodules` or you pulled the submodules after the clone using `git submodule update --init --recursive`
+2. You have the "luajit", "luasocket", "libssl-dev" and "make" packages installed.
+3. You are not running inside arm 
+
+With the dependencies fulfilled, you can run: 
+
 ```bash
+# There are two wrk2 folders: one in the root of the repository and one inside the socialNetwork folder. This is the first one.
 cd ../wrk2
+# Compile
 make
 ```
-back to socialNetwork
+
+And then go back to the socialNetwork folder to run the wrk2 properly for the system.
 ```bash
+# Back to socialNetwork, in the root folder.
 cd ../socialNetwork
 ```
 
 #### Compose posts
 
 ```bash
-../wrk2/wrk -D exp -t <num-threads> -c <num-conns> -d <duration> -L -s ./wrk2/scripts/social-network/compose-post.lua http://localhost:8080/wrk2-api/post/compose -R <reqs-per-sec>
+../wrk2/wrk -D exp -t <num-threads> -c <num-conns> -d <duration> -L -s ./wrk2/scripts/social-network/compose-post.lua http://<nginx-ip>:8080/wrk2-api/post/compose -R <reqs-per-sec>
+```
+
+Example:
+```bash
+../wrk2/wrk -D exp -t 12 -c 400 -d 300 -L -s ./wrk2/scripts/social-network/compose-post.lua http://10.109.126.103:8080/wrk2-api/post/compose -R 10
 ```
 
 #### Read home timelines

--- a/socialNetwork/helm-chart/socialnetwork/templates/_baseDeployment.tpl
+++ b/socialNetwork/helm-chart/socialnetwork/templates/_baseDeployment.tpl
@@ -47,10 +47,10 @@ spec:
         {{- end }}
         {{- if .resources }}  
         resources:
-          {{ tpl .resources $ | nindent 10 | trim }}
+          {{ toYaml .resources | nindent 10 | trim }}
         {{- else if hasKey $.Values.global "resources" }}           
         resources:
-          {{ tpl $.Values.global.resources $ | nindent 10 | trim }}
+          {{ toYaml $.Values.global.resources | nindent 10 | trim }}
         {{- end }}  
         {{- if $.Values.configMaps }}        
         volumeMounts: 
@@ -77,4 +77,5 @@ spec:
       hostname: {{ $.Values.name }}
       restartPolicy: {{ .Values.restartPolicy | default .Values.global.restartPolicy}}
 
-  {{- end}}
+{{ include "socialnetwork.templates.baseHPA" . }}
+{{- end}}

--- a/socialNetwork/helm-chart/socialnetwork/templates/_baseDeployment.tpl
+++ b/socialNetwork/helm-chart/socialnetwork/templates/_baseDeployment.tpl
@@ -45,7 +45,7 @@ spec:
         - {{ $arg }}
         {{- end -}}
         {{- end }}
-        {{- if .resources }}  
+        {{- if hasKey . "resources" }}  
         resources:
           {{ toYaml .resources | nindent 10 | trim }}
         {{- else if hasKey $.Values.global "resources" }}           

--- a/socialNetwork/helm-chart/socialnetwork/templates/_baseHPA.tpl
+++ b/socialNetwork/helm-chart/socialnetwork/templates/_baseHPA.tpl
@@ -17,7 +17,7 @@ spec:
   minReplicas: {{ default 1 .Values.global.hpa.minReplicas }}
   {{- end}}
   {{- if and .Values.hpa .Values.hpa.maxReplicas}}
-  minReplicas: {{ .Values.hpa.maxReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
   {{- else}}
   maxReplicas: {{ default 1 .Values.global.hpa.maxReplicas }}
   {{- end}}

--- a/socialNetwork/helm-chart/socialnetwork/templates/_baseHPA.tpl
+++ b/socialNetwork/helm-chart/socialnetwork/templates/_baseHPA.tpl
@@ -1,0 +1,50 @@
+{{- define "socialnetwork.templates.baseHPA" }}
+
+{{- if or (and .Values.hpa .Values.hpa.enabled) ($.Values.global.hpa.enabled) -}}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name:  {{ .Values.name }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}
+  {{- if and .Values.hpa .Values.hpa.minReplicas}}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  {{- else}}
+  minReplicas: {{ default 1 .Values.global.hpa.minReplicas }}
+  {{- end}}
+  {{- if and .Values.hpa .Values.hpa.maxReplicas}}
+  minReplicas: {{ .Values.hpa.maxReplicas }}
+  {{- else}}
+  maxReplicas: {{ default 1 .Values.global.hpa.maxReplicas }}
+  {{- end}}
+  metrics:
+  {{- if or $.Values.global.hpa.targetMemoryUtilizationPercentage (and .Values.hpa .Values.hpa.targetMemoryUtilizationPercentage) }}  
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          {{- if and .Values.hpa .Values.hpa.targetMemoryUtilizationPercentage }}
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+          {{- else }}
+          averageUtilization: {{ $.Values.global.hpa.targetMemoryUtilizationPercentage }}
+          {{- end}}
+  {{- end }}
+  {{- if or $.Values.global.hpa.targetCPUUtilizationPercentage (and .Values.hpa .Values.hpa.targetCPUUtilizationPercentage) }}  
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          {{- if and .Values.hpa .Values.hpa.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+          {{- else }}
+          averageUtilization: {{ $.Values.global.hpa.targetCPUUtilizationPercentage }}
+          {{- end}}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/socialNetwork/helm-chart/socialnetwork/templates/_baseNginxDeployment.tpl
+++ b/socialNetwork/helm-chart/socialnetwork/templates/_baseNginxDeployment.tpl
@@ -44,10 +44,10 @@ spec:
         {{- end }}
         {{- if .resources }}  
         resources:
-          {{ tpl .resources $ | nindent 10 | trim }}
+          {{ toYaml .resources | nindent 10 | trim }}
         {{- else if hasKey $.Values.global "resources" }}           
         resources:
-          {{ tpl $.Values.global.resources $ | nindent 10 | trim }}
+          {{ toYaml $.Values.global.resources | nindent 10 | trim }}
         {{- end }}  
         {{- if $.Values.configMaps }}        
         volumeMounts: 
@@ -74,10 +74,10 @@ spec:
         {{- end -}}
         {{- if .resources }}
         resources:
-          {{ tpl .resources $ | nindent 10 | trim }}
+          {{ toYaml .resources | nindent 10 | trim }}
         {{- else if hasKey $.Values.global "resources" }}
         resources:
-          {{ tpl $.Values.global.resources $ | nindent 10 | trim }}
+          {{ toYaml $.Values.global.resources | nindent 10 | trim }}
         {{- end }}
         {{- if .env }}
         env:
@@ -122,4 +122,5 @@ spec:
       hostname: {{ $.Values.name }}
       restartPolicy: {{ .Values.restartPolicy | default .Values.global.restartPolicy}}
 
-  {{- end}}
+{{ include "socialnetwork.templates.baseHPA" . }}
+{{- end}}

--- a/socialNetwork/helm-chart/socialnetwork/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/values.yaml
@@ -1,4 +1,17 @@
 global: 
+  hpa:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    targetMemoryUtilizationPercentage: '60'
+    targetCPUUtilizationPercentage: '60'
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
   replicas: 1
   imagePullPolicy: "IfNotPresent"
   restartPolicy: Always


### PR DESCRIPTION
This PR introduces the support for Kubernetes HPA for the helm-chart deployment of socialNetwork and fixes the resource fields, which are not working today. Also, it adds some details for the usage of wrk2 in socialNetwork documentation. If you want, I can split this into two different PRs.