### PR TITLE
fix (hotelReservation): "permission denied" caused by entrypoints of microservices

### DIFF
--- a/hotelReservation/docker-compose.yml
+++ b/hotelReservation/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - LOG_LEVEL
     build: .
     image: deathstarbench/hotel-reservation:latest
-    entrypoint: ./frontend
+    entrypoint: frontend
     ports:
       - "5000:5000"
     depends_on:
@@ -47,7 +47,7 @@ services:
       - LOG_LEVEL
     build: .
     image: deathstarbench/hotel-reservation:latest
-    entrypoint: ./profile
+    entrypoint: profile
     depends_on:
       - mongodb-profile
       - memcached-profile
@@ -69,7 +69,7 @@ services:
       - LOG_LEVEL
     build: .
     image: deathstarbench/hotel-reservation:latest
-    entrypoint: ./search
+    entrypoint: search
     depends_on:
       - consul
     restart: always
@@ -89,7 +89,7 @@ services:
       - LOG_LEVEL
     build: .
     image: deathstarbench/hotel-reservation:latest
-    entrypoint: ./geo
+    entrypoint: geo
     depends_on:
       - mongodb-geo
       - consul
@@ -110,7 +110,7 @@ services:
       - LOG_LEVEL
     build: .
     image: deathstarbench/hotel-reservation:latest
-    entrypoint: ./rate
+    entrypoint: rate
     depends_on:
       - mongodb-rate
       - memcached-rate
@@ -165,7 +165,7 @@ services:
       - LOG_LEVEL
     build: .
     image: deathstarbench/hotel-reservation:latest
-    entrypoint: ./recommendation
+    entrypoint: recommendation
     depends_on:
       - mongodb-recommendation
       - consul
@@ -186,7 +186,7 @@ services:
       - LOG_LEVEL
     build: .
     image: deathstarbench/hotel-reservation:latest
-    entrypoint: ./user
+    entrypoint: user
     depends_on:
       - mongodb-user
       - consul
@@ -207,7 +207,7 @@ services:
       - LOG_LEVEL
     build: .
     image: deathstarbench/hotel-reservation:latest
-    entrypoint: ./reservation
+    entrypoint: reservation
     depends_on:
       - mongodb-reservation
       - memcached-reserve


### PR DESCRIPTION
As mentioned in this issue #338, when using `docker compose up --build -d" command building the hotelResevration application, you will get a "permission denied" error. As explained in [this post](https://stackoverflow.com/a/78467492/3768871) by David Maze, the root cause of the problem and its solution are as follows :

> In your source tree, `/workspace/cmd/recommendation` is the _directory_ containing your Go source files.  You're trying to set that directory as the image's entrypoint override, and that won't work; it needs to be a command.
> 
> You're using [`go install`](https://pkg.go.dev/cmd/go#hdr-Compile_and_install_packages_and_dependencies) to compile all of the embedded commands at once.  That puts the packages in `$GOPATH/bin` or `$HOME/go/bin`.  The [`golang` Dockerfile](https://github.com/docker-library/golang/blob/777111946489bad416e54e378d580f2518632a82/1.21/bookworm/Dockerfile#L115-L116) sets `$GOPATH` to `/go` and adds it to the front of `$PATH`, so you should be able to directly run these `go install`ed commands in your Compose file, without specifying any sort of path
> 
> ```yaml
> services:
>   recommendation:
>     build: .
>     command: recommendation
> ```

Hence, as I have successfully tried his solution to resolve the problem and as the explanation seems plausible to me, I have created this pull request to fix this issue. 