### PR TITLE
fix (hotelReservation): the number of replicas and ports were not aligned for frontend microservice

### DIFF
--- a/hotelReservation/docker-compose.yml
+++ b/hotelReservation/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - consul
     restart: always
     deploy:
-      replicas: 3
+      replicas: 1
       restart_policy:
         condition: any
 


### PR DESCRIPTION
The number of replicas for `frontend` microservice in the `docker-compose.yaml` file is not aligned with the port range mentioned there: `5000:5000`. It can cause a starting time error when running `docker compose up` command, as follows:

```
Error response from daemon: driver failed programming external connectivity on endpoint 
hotelreservation-frontend-1 (1d94b64d9fa0e6d71e1584792b4dc24cce44cbfecf988d5c0f75e831557d0f04): 
Bind for 0.0.0.0:5000 failed: port is already allocated
```
One solution is to change the port range in the file, for example, from the following:
```yaml
ports:
  - "5000:5000"
```
to the following:
```yaml
ports:
  - "5000-5002"
```
 Or just decrease the number of replicas for the microservice from 3 to 1. The latter was done in this pull request for the sake of simplicity and safety. Because for applying the former solution, we should be careful about dependencies of other commands and microservices.

