### PR TITLE
using an alternative method for setting resource limits and requests

### DIFF
--- a/socialNetwork/helm-chart/README.md
+++ b/socialNetwork/helm-chart/README.md
@@ -168,23 +168,25 @@ $ helm install RELEASE_NAME HELM_CHART_REPO_PATH \
 --set compose-post-service.container.resources.limits.cpu=500m
 
 > **Alternatively upgrade**: Upgrade existing RELEASE via helm upgrade:\
-$ helm upgrade social-net3 ./socialnetwork \
---namespace social-network3 \
---set global.resources.requests.memory=64Mi \
---set global.resources.requests.cpu=100m \
---set global.resources.limits.memory=128Mi \
---set global.resources.limits.cpu=200m \
 
-helm upgrade social-net3 ./socialnetwork \
+helm install social-net1 socialnetwork \
+--namespace social-network \
+--set global.resources.requests.memory=128Mi \
+--set global.resources.requests.cpu=200m \
+--set global.resources.limits.memory=256Mi \
+--set global.resources.limits.cpu=400m \
+--set jaeger.container.resources.requests.memory=1024Mi \
+--set jaeger.container.resources.requests.cpu=500m \
+--set jaeger.container.resources.limits.memory=2048Mi \
+--set jaeger.container.resources.limits.cpu=1000m
+
+$ helm upgrade social-net3 socialnetwork \
 --namespace social-network3 \
 --set global.resources.requests.memory=128Mi \
 --set global.resources.requests.cpu=200m \
 --set global.resources.limits.memory=256Mi \
 --set global.resources.limits.cpu=400m \
---set jaeger.container.resources.requests.memory= 1024Mi \
---set jaeger.container.resources.requests.cpu=500m \
---set jaeger.container.resources.limits.memory= 2048 Mi \
---set jaeger.container.resources.limits.cpu=1000m
+s
 
 If one resources key is not specified, the value is retrieved from global values (which can be overriden during deployment).
 

--- a/socialNetwork/helm-chart/README.md
+++ b/socialNetwork/helm-chart/README.md
@@ -183,7 +183,7 @@ helm install social-net1 socialnetwork \
 
 ```
 $ helm upgrade social-net1 socialnetwork \
---namespace social-network3 \
+--namespace social-network1 \
 --set global.resources.requests.memory=128Mi \
 --set global.resources.requests.cpu=200m \
 --set global.resources.limits.memory=256Mi \

--- a/socialNetwork/helm-chart/README.md
+++ b/socialNetwork/helm-chart/README.md
@@ -175,7 +175,16 @@ $ helm upgrade social-net3 ./socialnetwork \
 --set global.resources.limits.memory=128Mi \
 --set global.resources.limits.cpu=200m \
 
-
+helm upgrade social-net3 ./socialnetwork \
+--namespace social-network3 \
+--set global.resources.requests.memory=128Mi \
+--set global.resources.requests.cpu=200m \
+--set global.resources.limits.memory=256Mi \
+--set global.resources.limits.cpu=400m \
+--set jaeger.container.resources.requests.memory= 1024Mi \
+--set jaeger.container.resources.requests.cpu=500m \
+--set jaeger.container.resources.limits.memory= 2048 Mi \
+--set jaeger.container.resources.limits.cpu=1000m
 
 If one resources key is not specified, the value is retrieved from global values (which can be overriden during deployment).
 

--- a/socialNetwork/helm-chart/README.md
+++ b/socialNetwork/helm-chart/README.md
@@ -171,10 +171,10 @@ $ helm install RELEASE_NAME HELM_CHART_REPO_PATH \
 ```
 helm install social-net1 socialnetwork \
 --namespace social-network \
---set global.resources.requests.memory=128Mi \
---set global.resources.requests.cpu=200m \
---set global.resources.limits.memory=256Mi \
---set global.resources.limits.cpu=400m \
+--set global.resources.requests.memory=256Mi \
+--set global.resources.requests.cpu=400m \
+--set global.resources.limits.memory=512Mi \
+--set global.resources.limits.cpu=800m \
 --set jaeger.container.resources.requests.memory=1024Mi \
 --set jaeger.container.resources.requests.cpu=500m \
 --set jaeger.container.resources.limits.memory=2048Mi \

--- a/socialNetwork/helm-chart/README.md
+++ b/socialNetwork/helm-chart/README.md
@@ -168,7 +168,7 @@ $ helm install RELEASE_NAME HELM_CHART_REPO_PATH \
 --set compose-post-service.container.resources.limits.cpu=500m
 
 > **Alternatively upgrade**: Upgrade existing RELEASE via helm upgrade:\
-
+```
 helm install social-net1 socialnetwork \
 --namespace social-network \
 --set global.resources.requests.memory=128Mi \
@@ -179,14 +179,16 @@ helm install social-net1 socialnetwork \
 --set jaeger.container.resources.requests.cpu=500m \
 --set jaeger.container.resources.limits.memory=2048Mi \
 --set jaeger.container.resources.limits.cpu=1000m
+```
 
-$ helm upgrade social-net3 socialnetwork \
+```
+$ helm upgrade social-net1 socialnetwork \
 --namespace social-network3 \
 --set global.resources.requests.memory=128Mi \
 --set global.resources.requests.cpu=200m \
 --set global.resources.limits.memory=256Mi \
---set global.resources.limits.cpu=400m \
-s
+--set global.resources.limits.cpu=400m 
+```
 
 If one resources key is not specified, the value is retrieved from global values (which can be overriden during deployment).
 

--- a/socialNetwork/helm-chart/README.md
+++ b/socialNetwork/helm-chart/README.md
@@ -159,13 +159,13 @@ $ helm install RELEASE_NAME HELM_CHART_REPO_PATH \
 $ helm install RELEASE_NAME HELM_CHART_REPO_PATH \
 --namespace YOUR_NAMESPACE \
 --set global.resources.requests.memory=64Mi \
---set global.resources.requests.cpu=250m \
---set global.resources.limits.memory=128Mi \
---set global.resources.limits.cpu=2 \
+--set global.resources.requests.cpu=150m \
+--set global.resources.limits.memory=256Mi \
+--set global.resources.limits.cpu=300m \
 --set compose-post-service.container.resources.requests.memory=64Mi \
---set compose-post-service.container.resources.requests.cpu=500m \
---set compose-post-service.container.resources.limits.memory=128Mi \
---set compose-post-service.container.resources.limits.cpu=4
+--set compose-post-service.container.resources.requests.cpu=300m \
+--set compose-post-service.container.resources.limits.memory=256Mi \
+--set compose-post-service.container.resources.limits.cpu=500m
 
 > **Alternatively upgrade**: Upgrade existing RELEASE via helm upgrade:\
 $ helm upgrade social-net3 ./socialnetwork \

--- a/socialNetwork/helm-chart/README.md
+++ b/socialNetwork/helm-chart/README.md
@@ -155,7 +155,7 @@ $ helm install RELEASE_NAME HELM_CHART_REPO_PATH \
 > **Attention**: indentations are important in string parameters.
 
 > **Alternatively**: using --set instead of --set-string to allow Helm to correctly parse the nested structure:\
-$ helm install RELEASE_NAME HELM_CHART_REPO_PAT \
+$ helm install RELEASE_NAME HELM_CHART_REPO_PATH \
 --namespace YOUR_NAMESPACE \
 --set global.resources.requests.memory=64Mi \
 --set global.resources.requests.cpu=250m \

--- a/socialNetwork/helm-chart/README.md
+++ b/socialNetwork/helm-chart/README.md
@@ -152,9 +152,10 @@ $ helm install RELEASE_NAME HELM_CHART_REPO_PATH \
       memory: "128Mi"
       cpu: "4""
 ```
+
 > **Attention**: indentations are important in string parameters.
 
-> **Alternatively**: using --set instead of --set-string to allow Helm to correctly parse the nested structure:\
+> **Alternatively install**: using --set instead of --set-string to allow Helm to correctly parse the nested structure:\
 $ helm install RELEASE_NAME HELM_CHART_REPO_PATH \
 --namespace YOUR_NAMESPACE \
 --set global.resources.requests.memory=64Mi \
@@ -166,6 +167,13 @@ $ helm install RELEASE_NAME HELM_CHART_REPO_PATH \
 --set compose-post-service.container.resources.limits.memory=128Mi \
 --set compose-post-service.container.resources.limits.cpu=4
 
+> **Alternatively upgrade**: Upgrade existing RELEASE via helm upgrade:\
+$ helm upgrade social-net3 ./socialnetwork \
+--namespace social-network3 \
+--set global.resources.requests.memory=64Mi \
+--set global.resources.requests.cpu=100m \
+--set global.resources.limits.memory=128Mi \
+--set global.resources.limits.cpu=200m \
 
 
 

--- a/socialNetwork/helm-chart/README.md
+++ b/socialNetwork/helm-chart/README.md
@@ -154,6 +154,21 @@ $ helm install RELEASE_NAME HELM_CHART_REPO_PATH \
 ```
 > **Attention**: indentations are important in string parameters.
 
+> **Alternatively**: using --set instead of --set-string to allow Helm to correctly parse the nested structure:\
+$ helm install RELEASE_NAME HELM_CHART_REPO_PAT \
+--namespace YOUR_NAMESPACE \
+--set global.resources.requests.memory=64Mi \
+--set global.resources.requests.cpu=250m \
+--set global.resources.limits.memory=128Mi \
+--set global.resources.limits.cpu=2 \
+--set compose-post-service.container.resources.requests.memory=64Mi \
+--set compose-post-service.container.resources.requests.cpu=500m \
+--set compose-post-service.container.resources.limits.memory=128Mi \
+--set compose-post-service.container.resources.limits.cpu=4
+
+
+
+
 If one resources key is not specified, the value is retrieved from global values (which can be overriden during deployment).
 
 > [Kubernetes container resources management documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)

--- a/socialNetwork/helm-chart/socialnetwork/charts/jaeger/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/jaeger/values.yaml
@@ -19,25 +19,24 @@ ports:
   - port: 9411
     targetPort: 9411
 
-
 container:
-  env: 
-  - name: COLLECTOR_ZIPKIN_HTTP_PORT
-    value: 9411
+  env:
+    - name: COLLECTOR_ZIPKIN_HTTP_PORT
+      value: 9411
   image: jaegertracing/all-in-one
-  imageVersion: latest
+  imageVersion: 1.62.0
   name: jaeger
-  ports: 
-  - containerPort: 5775
-    protocol: UDP
-  - containerPort: 6831
-    protocol: UDP
-  - containerPort: 6832
-    protocol: UDP
-  - containerPort: 5778
-  - containerPort: 16686
-  - containerPort: 14268
-  - containerPort: 9411
+  ports:
+    - containerPort: 5775
+      protocol: UDP
+    - containerPort: 6831
+      protocol: UDP
+    - containerPort: 6832
+      protocol: UDP
+    - containerPort: 5778
+    - containerPort: 16686
+    - containerPort: 14268
+    - containerPort: 9411
 
 configMaps:
   - name: jaeger-config.yml


### PR DESCRIPTION
The provided method for setting resource requests and limits is easy to produce installation errors.
An alternative method can be used by adopting --set instead of --set-string to allow Helm to correctly parse the nested structure.

![image](https://github.com/delimitrou/DeathStarBench/assets/5981694/85507f3f-ffa7-4826-a169-9a59a16beaf7)
