### PR TITLE
Fix: Issue 347. Request per second must be >= threads. Throw an error when conflicts.

### DIFF
--- a/socialNetwork/README.md
+++ b/socialNetwork/README.md
@@ -87,7 +87,7 @@ cd ../socialNetwork
 
 Example:
 ```bash
-../wrk2/wrk -D exp -t 12 -c 400 -d 300 -L -s ./wrk2/scripts/social-network/compose-post.lua http://10.109.126.103:8080/wrk2-api/post/compose -R 10
+../wrk2/wrk -D exp -t 5 -c 400 -d 300 -L -s ./wrk2/scripts/social-network/compose-post.lua http://10.109.126.103:8080/wrk2-api/post/compose -R 10
 ```
 
 #### Read home timelines

--- a/wrk2/src/wrk.c
+++ b/wrk2/src/wrk.c
@@ -970,6 +970,11 @@ static int parse_args(struct config *cfg, char ***urls, struct http_parser_url *
         return -1;
     }
 
+    if (cfg->rate < cfg->threads){
+        fprintf(stderr, "Request per sec must be >= threads\n");
+        return -1;
+    }
+
     for(int i = optind; i<argc; i++)
     {   
         if (!script_parse_url(argv[i], *mul_part)) {


### PR DESCRIPTION
This is a fix for [Issue 347](https://github.com/delimitrou/DeathStarBench/issues/347#issue-2570700527). `wrk` throws an error when `cfg->rate < cfg->threads`. The thread number in tutorial is adjust to 5.