### PR TITLE
Fix jaeger-agent deprecation in socialNetwork

### DIFF
--- a/socialNetwork/helm-chart/socialnetwork/charts/jaeger/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/jaeger/values.yaml
@@ -25,7 +25,7 @@ container:
   - name: COLLECTOR_ZIPKIN_HTTP_PORT
     value: 9411
   image: jaegertracing/all-in-one
-  imageVersion: latest
+  imageVersion: 1.62.0
   name: jaeger
   ports: 
   - containerPort: 5775


### PR DESCRIPTION
Upon the release of Jaeger 1.63.0/2.0.0, [the `jaeger-agent` has been deprecated](https://github.com/jaegertracing/jaeger/releases/tag/v1.63.0), meaning that the socialNetwork deployment no longer works with any version of `jaegertracing/all-in-one` > 1.62.0. 

I am creating a PR for a short term fix (revert back to the latest stable version of `jaegertracing/all-in-one` that includes the `jaeger-agent`), a longer term fix would involve moving away from `jaeger-agent` entirely.