### PR TITLE
 Pull request: fix K8s Deployments to run correct service binaries

### DIFF
--- a/hotelReservation/kubernetes/frontend/frontend-deployment.yaml
+++ b/hotelReservation/kubernetes/frontend/frontend-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - command:
-            - ./frontend
+            - frontend
           image: deathstarbench/hotel-reservation:latest
           name: hotel-reserv-frontend
           ports:

--- a/hotelReservation/kubernetes/geo/geo-deployment.yaml
+++ b/hotelReservation/kubernetes/geo/geo-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - command:
-            - ./geo
+            - geo
           image: deathstarbench/hotel-reservation:latest
           name: hotel-reserv-geo
           ports:

--- a/hotelReservation/kubernetes/profile/profile-deployment.yaml
+++ b/hotelReservation/kubernetes/profile/profile-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - command:
-            - ./profile
+            - profile
           image: deathstarbench/hotel-reservation:latest
           name: hotel-reserv-profile
           ports:

--- a/hotelReservation/kubernetes/rate/rate-deployment.yaml
+++ b/hotelReservation/kubernetes/rate/rate-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - command:
-            - ./rate
+            - rate
           image: deathstarbench/hotel-reservation:latest
           name: hotel-reserv-rate
           ports:

--- a/hotelReservation/kubernetes/reccomend/recommendation-deployment.yaml
+++ b/hotelReservation/kubernetes/reccomend/recommendation-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - command:
-            - ./recommendation
+            - recommendation
           image: deathstarbench/hotel-reservation:latest
           name: hotel-reserv-recommendation
           ports:

--- a/hotelReservation/kubernetes/reserve/reservation-deployment.yaml
+++ b/hotelReservation/kubernetes/reserve/reservation-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - command:
-            - ./reservation
+            - reservation
           image: deathstarbench/hotel-reservation:latest
           name: hotel-reserv-reservation
           ports:

--- a/hotelReservation/kubernetes/scripts/build-docker-images.sh
+++ b/hotelReservation/kubernetes/scripts/build-docker-images.sh
@@ -5,7 +5,7 @@ cd $(dirname $0)/..
 
 EXEC="docker buildx"
 
-USER="igorrudyk1"
+USER="novatasha"
 
 TAG="latest"
 

--- a/hotelReservation/kubernetes/search/search-deployment.yaml
+++ b/hotelReservation/kubernetes/search/search-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - command:
-            - ./search
+            - search
           image: deathstarbench/hotel-reservation:latest
           name: hotel-reserv-search
           ports:

--- a/hotelReservation/kubernetes/user/user-deployment.yaml
+++ b/hotelReservation/kubernetes/user/user-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - command:
-            - ./user
+            - user
           image: deathstarbench/hotel-reservation:latest
           name: hotel-reserv-user
           ports:


### PR DESCRIPTION
Summary
Pods failed to start because the manifests tried to run ./<svc>, but the binaries live in /go/bin. This PR updates the command to call the binary by name, relying on the image PATH (which includes /go/bin).

What changed

For each service (frontend, geo, profile, rate, recommendation, reservation, search, user), set:

command: ["<svc>"]
instead of ./<svc> or an absolute path.

Why this is needed

Events showed:

RunContainerError: exec: "./<svc>": stat ./<svc>: no such file or directory


The image installs built binaries under /go/bin/<svc>.

Calling the binary by name works because /go/bin is on PATH.

### How it was tested

Applied the updated Deployments on a clean minikube cluster.

Verified rollout:

kubectl rollout status deploy/<svc>
kubectl get pods


Reached the frontend via port-forward and ran a simple request:
```Bash
kubectl port-forward svc/frontend 5000:5000 &
curl -f http://localhost:5000/ || true
```

Sanity check from a pod:

```Bash
kubectl run curl --rm -it --image=curlimages/curl -- \
  curl -sS http://frontend.<ns>.svc.cluster.local:5000/health
```


Checklist

- [X] Pods reach Running for all updated services.
- [X] kubectl apply --dry-run=server passes.
- [X] Basic request path returns a 200.